### PR TITLE
chore(cli): add postman collection with pkce

### DIFF
--- a/cli/MGC.postman_collection.json
+++ b/cli/MGC.postman_collection.json
@@ -1,0 +1,472 @@
+{
+	"info": {
+		"_postman_id": "f419f113-a4da-43cd-ba9e-8dbb9052a14b",
+		"name": "MGC",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Block Storage / Volume",
+			"item": [
+				{
+					"name": "CREATE Volume",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"region\":\"br-ne-1\",\"slug\":\"pf-test-2\",\"is_public\":false}"
+						},
+						"url": {
+							"raw": "{{mgc_block_storage_url}}/v0/volumes",
+							"host": [
+								"{{mgc_block_storage_url}}"
+							],
+							"path": [
+								"v0",
+								"volumes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "LIST Volume",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{mgc_block_storage_url}}/v0/volumes",
+							"host": [
+								"{{mgc_block_storage_url}}"
+							],
+							"path": [
+								"v0",
+								"volumes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE Volume",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_block_storage_url}}/v0/volumes/{{volume_id}}",
+							"host": [
+								"{{mgc_block_storage_url}}"
+							],
+							"path": [
+								"v0",
+								"volumes",
+								"{{volume_id}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Compute Instances / VM",
+			"item": [
+				{
+					"name": "LIST Instances",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{mgc_vm_url}}/v0/instances",
+							"host": [
+								"{{mgc_vm_url}}"
+							],
+							"path": [
+								"v0",
+								"instances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET Instance By ID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_vm_url}}/v0/instances/{{instance_id}}",
+							"host": [
+								"{{mgc_vm_url}}"
+							],
+							"path": [
+								"v0",
+								"instances",
+								"{{instance_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "CREATE Instance",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"name\":\"pf-instance-1\",\"region\":\"br-ne-1\",\"image\":\"cloud-centos-09 LTS\",\"type\":\"cloud-bs1.xsmall\",\"ssh_key\":\"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPgMsh5ZUifYjCblgnvV3D9xl++RBkr3vMXtT+7eQrVa hspedro@profusion.mobi\",\"key_name\":\"hspedro\"}"
+						},
+						"url": {
+							"raw": "{{mgc_vm_url}}/v0/instances",
+							"host": [
+								"{{mgc_vm_url}}"
+							],
+							"path": [
+								"v0",
+								"instances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE Instance",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_vm_url}}/v0/instances/{{instance_id}}",
+							"host": [
+								"{{mgc_vm_url}}"
+							],
+							"path": [
+								"v0",
+								"instances",
+								"{{instance_id}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Banco de Dados / DB",
+			"item": [
+				{
+					"name": "CREATE DB",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"engine_id\":\"063f3994-b6c2-4c37-96c9-bab8d82d36f7\",\"flavor_id\":\"3c6b14a4-455c-4e1b-8df1-2a0f39ac3cef\",\"name\":\"pf-db-1\",\"password\":\"admin\",\"user\":\"admin\",\"volume_size\":100,\"backup\":{\"retention_days\":7,\"start_at\":\"02:00:00\"}}"
+						},
+						"url": {
+							"raw": "{{mgc_dbass_url}}/v1/instances",
+							"host": [
+								"{{mgc_dbass_url}}"
+							],
+							"path": [
+								"v1",
+								"instances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "LIST DBs",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_dbass_url}}/v1/instances",
+							"host": [
+								"{{mgc_dbass_url}}"
+							],
+							"path": [
+								"v1",
+								"instances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET DB By ID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_dbass_url}}/v1/instances/{{instance_id}}",
+							"host": [
+								"{{mgc_dbass_url}}"
+							],
+							"path": [
+								"v1",
+								"instances",
+								"{{instance_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE DB",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_dbass_url}}/v1/instances/{{instance_id}}",
+							"host": [
+								"{{mgc_dbass_url}}"
+							],
+							"path": [
+								"v1",
+								"instances",
+								"{{instance_id}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "K8S",
+			"item": [
+				{
+					"name": "CREATE Cluster",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\"name\":\"pf-cluster-1\",\"version\":\"v1.24.10\",\"node_pool\":{\"name\":\"pf-node-pool-1\",\"flavor\":\"cloud-k8s.gp1.small\",\"replicas\":1}}"
+						},
+						"url": {
+							"raw": "{{mgc_k8s_url}}/v1/clusters",
+							"host": [
+								"{{mgc_k8s_url}}"
+							],
+							"path": [
+								"v1",
+								"clusters"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "LIST Clusters",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_k8s_url}}/v1/clusters",
+							"host": [
+								"{{mgc_k8s_url}}"
+							],
+							"path": [
+								"v1",
+								"clusters"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GET Cluster By ID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_k8s_url}}/v1/clusters/{{cluster_id}}",
+							"host": [
+								"{{mgc_k8s_url}}"
+							],
+							"path": [
+								"v1",
+								"clusters",
+								"{{cluster_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "DELETE Cluster",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{mgc_k8s_url}}/v1/clusters/{{cluster_id}}",
+							"host": [
+								"{{mgc_k8s_url}}"
+							],
+							"path": [
+								"v1",
+								"clusters",
+								"{{cluster_id}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "oauth2",
+		"oauth2": [
+			{
+				"key": "useBrowser",
+				"value": false,
+				"type": "boolean"
+			},
+			{
+				"key": "redirect_uri",
+				"value": "{{mgc_redirect_uri}}",
+				"type": "string"
+			},
+			{
+				"key": "clientSecret",
+				"value": "",
+				"type": "string"
+			},
+			{
+				"key": "scope",
+				"value": "{{mgc_scopes}}",
+				"type": "string"
+			},
+			{
+				"key": "tokenName",
+				"value": "mgc_access_token",
+				"type": "string"
+			},
+			{
+				"key": "challengeAlgorithm",
+				"value": "S256",
+				"type": "string"
+			},
+			{
+				"key": "grant_type",
+				"value": "authorization_code_with_pkce",
+				"type": "string"
+			},
+			{
+				"key": "clientId",
+				"value": "{{mgc_client_id}}",
+				"type": "string"
+			},
+			{
+				"key": "authUrl",
+				"value": "https://id.magalu.com/login",
+				"type": "string"
+			},
+			{
+				"key": "addTokenTo",
+				"value": "header",
+				"type": "string"
+			},
+			{
+				"key": "client_authentication",
+				"value": "header",
+				"type": "string"
+			},
+			{
+				"key": "accessTokenUrl",
+				"value": "https://id.magalu.com/oauth/token",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "mgc_client_uuid",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "mgc_client_id",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "mgc_client_secret",
+			"value": "",
+			"type": "default"
+		},
+		{
+			"key": "mgc_scopes",
+			"value": "openid mke.write network.read network.write object-storage.read object-storage.write api-consulta.read block-storage.read block-storage.write mke.read virtual-machine.read virtual-machine.write dbaas.read dbaas.write cpo:read cpo:write",
+			"type": "default"
+		},
+		{
+			"key": "mgc_redirect_uri",
+			"value": "http://localhost:8095/callback",
+			"type": "default"
+		},
+		{
+			"key": "mgc_block_storage_url",
+			"value": "https://api-block-storage.br-ne-1.jaxyendy.com",
+			"type": "default"
+		},
+		{
+			"key": "mgc_vm_url",
+			"value": "https://api-virtual-machine.br-ne-1.jaxyendy.com",
+			"type": "default"
+		},
+		{
+			"key": "mgc_dbass_url",
+			"value": "https://api-dbaas.br-ne-1.jaxyendy.com",
+			"type": "default"
+		},
+		{
+			"key": "mgc_k8s_url",
+			"value": "https://api-mke.br-ne-1.jaxyendy.com",
+			"type": "default"
+		}
+	]
+}


### PR DESCRIPTION

## Description

This collection is already configured to perform the PKCE authentication and execute the basic operations on the endpoints.

The body or path of some requests might be outdated due to services being unavailable for validation

## Related Issues
- Related to #7 

## How to test it

- Open Postman and import collection
- Click on the collection and the variables tab
- Add secret information like ClientID, ClientSecret, etc.. (Add on the currentValue column to keep leaks from happening)
- Execute one operation like list Databases or Virtual Machines
- It should be successful and the mgc_access_token should now have a valid token value


