### PR TITLE
chore: add script to remove tenant id from spec

### DIFF
--- a/mgc/cli/openapis/block-storage.openapi.yaml
+++ b/mgc/cli/openapis/block-storage.openapi.yaml
@@ -103,14 +103,6 @@ paths:
                     format: string
                 name: quota_slug
                 in: query
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -134,15 +126,6 @@ paths:
             summary: List snapshots
             description: List snapshots
             operationId: list_snapshots_v0_snapshots_get
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -165,15 +148,6 @@ paths:
             summary: Create snapshot
             description: Create snapshot
             operationId: create_snapshot_v0_snapshots_post
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -212,14 +186,6 @@ paths:
                     format: uuid
                 name: snapshot_id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -257,14 +223,6 @@ paths:
                     format: uuid
                 name: snapshot_id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -284,15 +242,6 @@ paths:
             summary: List Volumes
             description: Returns a list of volumes from the provided tenant_id
             operationId: list_volumes_v0_volumes_get
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -315,15 +264,6 @@ paths:
             summary: Create Volume
             description: Create a volume for a provided tenant_id
             operationId: create_volume_v0_volumes_post
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -362,14 +302,6 @@ paths:
                     format: uuid
                 name: id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -409,14 +341,6 @@ paths:
                     default: false
                 name: force
                 in: query
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -444,14 +368,6 @@ paths:
                     format: uuid
                 name: id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -499,14 +415,6 @@ paths:
                     format: uuid
                 name: virtual_machine_id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -565,14 +473,6 @@ paths:
                     default: false
                 name: force
                 in: query
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response

--- a/mgc/cli/openapis/virtual-machine.openapi.yaml
+++ b/mgc/cli/openapis/virtual-machine.openapi.yaml
@@ -195,15 +195,6 @@ paths:
             summary: List Instances
             description: Returns a list of instances for a provided tenant_id
             operationId: list_instances_v0_instances_get
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -226,15 +217,6 @@ paths:
             summary: Instance Create
             description: Create a instance asynchronously
             operationId: instance_create_v0_instances_post
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -273,14 +255,6 @@ paths:
                     format: uuid
                 name: id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -312,14 +286,6 @@ paths:
                     format: uuid
                 name: id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -347,14 +313,6 @@ paths:
                     format: uuid
                 name: id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -389,14 +347,6 @@ paths:
                     format: uuid
                 name: id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -437,14 +387,6 @@ paths:
                     format: uuid
                 name: event_id
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -468,15 +410,6 @@ paths:
             summary: List Keypairs
             description: Returns a list of keypairs from a provided tenant_id
             operationId: list_keypairs_v0_keypairs_get
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -499,15 +432,6 @@ paths:
             summary: Create Keypair
             description: Create a keypair
             operationId: create_keypair_v0_keypairs_post
-            parameters:
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -545,14 +469,6 @@ paths:
                     type: string
                 name: keypair_name
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '201':
                     description: Successful Response
@@ -583,14 +499,6 @@ paths:
                     type: string
                 name: keypair_name
                 in: path
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -620,14 +528,6 @@ paths:
                     format: string
                 name: quota_slug
                 in: query
-            -   description: x-tenant-id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1401,9 +1301,8 @@ components:
                     authorizationUrl: https://idp-maas-sandbox.ipet.sh/auth/realms/master/protocol/openid-connect/auth
                     tokenUrl: https://idp-maas-sandbox.ipet.sh/auth/realms/master/protocol/openid-connect/token
                     scopes:
-                        virtual-machine.read: "Ler informa\xE7\xF5es de recursos IaaS"
-                        virtual-machine.write: "Escrever informa\xE7\xF5es de recursos\
-                            \ IaaS"
+                        virtual-machine.read: Ler informações de recursos IaaS
+                        virtual-machine.write: Escrever informações de recursos IaaS
             type: oauth2
             description: OAuth2 via IDPA
 tags:

--- a/mgc/cli/openapis/vpc.openapi.yaml
+++ b/mgc/cli/openapis/vpc.openapi.yaml
@@ -42,14 +42,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -85,14 +77,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -142,14 +126,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -192,14 +168,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -234,14 +202,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -267,14 +227,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -306,14 +258,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -352,14 +296,6 @@ paths:
                     format: uuid
                 name: port_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -391,14 +327,6 @@ paths:
                     format: uuid
                 name: port_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -428,14 +356,6 @@ paths:
                         type: string
                 name: port_id_list
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -462,15 +382,6 @@ paths:
             summary: Delete Port All
             operationId: deleteAllPorts
             description: Delete all port from tenant
-            parameters:
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -511,14 +422,6 @@ paths:
                     format: uuid
                 name: security_group_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -558,14 +461,6 @@ paths:
                     format: uuid
                 name: security_group_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -597,14 +492,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -636,14 +523,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -682,14 +561,6 @@ paths:
                     format: uuid
                 name: public_ip_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -721,14 +592,6 @@ paths:
                     format: uuid
                 name: public_ip_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -765,14 +628,6 @@ paths:
                     format: uuid
                 name: port_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -812,14 +667,6 @@ paths:
                     format: uuid
                 name: port_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -842,15 +689,6 @@ paths:
             summary: Tenant's public IP list
             description: Return a tenant's public ip list
             operationId: tenantPublicIpList
-            parameters:
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -883,14 +721,6 @@ paths:
                     format: uuid
                 name: security_group_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -922,14 +752,6 @@ paths:
                     format: uuid
                 name: security_group_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -968,14 +790,6 @@ paths:
                     format: uuid
                 name: rule_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1007,14 +821,6 @@ paths:
                     format: uuid
                 name: rule_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -1049,14 +855,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1091,14 +889,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -1140,14 +930,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1182,14 +964,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -1215,14 +989,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1254,14 +1020,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -1300,14 +1058,6 @@ paths:
                     format: uuid
                 name: security_group_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1339,14 +1089,6 @@ paths:
                     format: uuid
                 name: security_group_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -1381,14 +1123,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1423,14 +1157,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -1472,14 +1198,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1514,14 +1232,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -1553,14 +1263,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1595,14 +1297,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -1636,14 +1330,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1679,14 +1365,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1721,14 +1399,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -1754,14 +1424,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1793,14 +1455,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -1845,14 +1499,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1882,14 +1528,6 @@ paths:
                     format: uuid
                 name: subnet_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1921,14 +1559,6 @@ paths:
                     format: uuid
                 name: subnet_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -1948,15 +1578,6 @@ paths:
             summary: Create Vpc Default
             operationId: create_vpc_default_v0_vpcs_default_post
             description: Create a default vpc
-            parameters:
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -1977,15 +1598,6 @@ paths:
             summary: List VPC
             description: Returns a list of VPCs for a provided tenant_id
             operationId: listVpcs
-            parameters:
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -2009,15 +1621,6 @@ paths:
             summary: Create VPC
             description: Create a VPC
             operationId: createVpc
-            parameters:
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -2056,14 +1659,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -2095,14 +1690,6 @@ paths:
                     format: uuid
                 name: vpc_id
                 in: path
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -2121,15 +1708,6 @@ paths:
             - vpc
             summary: Delete Vpc All
             operationId: deleteAllVpcs
-            parameters:
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             description: Delete all vpcs from tenant
             responses:
                 '200':
@@ -2159,14 +1737,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -2195,14 +1765,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -2229,14 +1791,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -2271,13 +1825,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -2313,14 +1860,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -2361,14 +1900,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -2406,14 +1937,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             requestBody:
                 content:
                     application/json:
@@ -2463,14 +1986,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '204':
                     description: Successful Response
@@ -2502,14 +2017,6 @@ paths:
                     $ref: '#/components/schemas/ProjectType'
                 name: project_type
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -2537,14 +2044,6 @@ paths:
                     $ref: '#/components/schemas/QuotaSlug'
                 name: quota_slug
                 in: query
-            -   description: Tenant Id
-                required: true
-                schema:
-                    title: X-Tenant-Id
-                    type: string
-                    format: uuid
-                name: x-tenant-id
-                in: header
             responses:
                 '200':
                     description: Successful Response
@@ -3426,10 +2925,8 @@ components:
                 updated: '2023-04-17T17:31:28Z'
                 subnetpool_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
                 external_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-                cidr_block: "[ATEN\xC7\xC3O] - Este campo futuramente substituir\xE1\
-                    \ 'cidr'"
-                ip_version: "[ATEN\xC7\xC3O] - Este campo futuramente substituir\xE1\
-                    \ 'ethertype'"
+                cidr_block: '[ATENÇÃO] - Este campo futuramente substituirá ''cidr'''
+                ip_version: '[ATENÇÃO] - Este campo futuramente substituirá ''ethertype'''
         SubnetsResponse:
             title: SubnetsResponse
             type: object
@@ -3472,10 +2969,8 @@ components:
                     updated: '2023-04-17T17:31:28Z'
                     subnetpool_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
                     external_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-                    cidr_block: "[ATEN\xC7\xC3O] - Este campo futuramente substituir\xE1\
-                        \ 'cidr'"
-                    ip_version: "[ATEN\xC7\xC3O] - Este campo futuramente substituir\xE1\
-                        \ 'ethertype'"
+                    cidr_block: '[ATENÇÃO] - Este campo futuramente substituirá ''cidr'''
+                    ip_version: '[ATENÇÃO] - Este campo futuramente substituirá ''ethertype'''
         ValidationError:
             title: ValidationError
             required:
@@ -3700,9 +3195,8 @@ components:
                     authorizationUrl: https://idp-maas-sandbox.ipet.sh/auth/realms/master/protocol/openid-connect/auth
                     tokenUrl: https://idp-maas-sandbox.ipet.sh/auth/realms/master/protocol/openid-connect/token
                     scopes:
-                        network.read: "Ler informa\xE7\xF5es de recursos VPC IaaS"
-                        network.write: "Escrever informa\xE7\xF5es de recursos VPC\
-                            \ IaaS"
+                        network.read: Ler informações de recursos VPC IaaS
+                        network.write: Escrever informações de recursos VPC IaaS
             type: oauth2
             description: 'OAuth2 via IDPA
 
@@ -3721,8 +3215,7 @@ tags:
 -   name: subnets
     description: Rotas relacionadas as apis da VPC API Product para Subnets
 -   name: healthcheck
-    description: "Rotas relacionadas a verifica\xE7\xE3o da sa\xFAde da aplica\xE7\
-        \xE3o"
+    description: Rotas relacionadas a verificação da saúde da aplicação
 -   name: xaas_vpc
     description: Rotas relacionadas as apis utilizadas por outros produtos
 -   name: xaas_subnetpools

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,3 +39,24 @@ python3 sync_oapi.py <url-to-internal-spec> <path-ext-yaml-spec> -o <output-path
 ```
 
 Where url to internal spec is something like: "https://vm-region.proxy.com/openapi.json"
+
+### [remove_tenant_id.py](./remove_tenant_id.py):
+
+Some external OpenAPI specs were shared with endpoints expecting
+`x-tenant-id` parameter in the header. However, this is not what we
+will have in production. Thus, we need to remove this parameter from
+the spec for now.
+
+#### Running
+
+For help:
+
+```shell
+python3 remove_tenant_id.py  --help
+```
+
+For running:
+
+```shell
+python3 remove_tenant_id.py <path-to-openapi-spec>
+```

--- a/scripts/remove_tenant_id.py
+++ b/scripts/remove_tenant_id.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict
+import argparse
+import yaml
+
+
+OAPISchema = Dict[str, Any]
+
+
+def load_yaml(path: str) -> OAPISchema:
+    with open(path, "r") as fd:
+        return yaml.load(fd, Loader=yaml.CLoader)
+
+
+def save_external(spec: OAPISchema, path: str):
+    with open(path, "w") as fd:
+        yaml.dump(spec, fd, sort_keys=False, indent=4, allow_unicode=True)
+
+
+def remove_param(spec: OAPISchema, param_name: str):
+    for path in spec.get("paths", {}).values():
+        for action in path.values():
+            if "parameters" not in action:
+                continue
+
+            filtered_params = [
+                p for p in action.get("parameters", [{}]) if p.get("name") != param_name
+            ]
+
+            if not filtered_params:
+                del action["parameters"]
+            else:
+                action["parameters"] = filtered_params
+
+
+def remove_tenant_id(spec: OAPISchema):
+    return remove_param(spec, param_name="x-tenant-id")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Remove `x-tenant-id` param from OpenAPI spec actions"
+    )
+    # External = Viveiro in MGC context, intermediate between product and Kong
+    parser.add_argument(
+        "path",
+        type=str,
+        help="File path to an OpenAPI spec to be parsed",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Path to save the modified YAML. Defaults to overwrite",
+    )
+    args = parser.parse_args()
+
+    spec = load_yaml(args.path)
+
+    remove_tenant_id(spec)
+
+    save_external(spec, args.output or args.path)


### PR DESCRIPTION
Some external OpenAPI specs were shared with endpoints expecting the `x-tenant-id` parameter in the header. However, this is not what we will have in production. Thus, we need to remove this parameter from the spec for now.

- Closes #34


```shell
python3 scripts/remove_tenant_id.py mgc/cli/openapi/virtual-machine.openapi.yaml
``` 