### PR TITLE
Add auth context

### DIFF
--- a/mgc/core/auth.go
+++ b/mgc/core/auth.go
@@ -1,0 +1,19 @@
+package core
+
+import "context"
+
+type Auth struct {
+	AccessToken  string
+	RefreshToken string
+}
+type authKey string
+
+var key = authKey("auth")
+
+func NewAuthContext(parentCtx context.Context, auth *Auth) context.Context {
+	return context.WithValue(parentCtx, key, auth)
+}
+func AuthFromContext(ctx context.Context) *Auth {
+	a, _ := ctx.Value(key).(*Auth)
+	return a
+}

--- a/mgc/sdk/sdk.go
+++ b/mgc/sdk/sdk.go
@@ -21,6 +21,7 @@ type Value = core.Value
 
 type Sdk struct {
 	group *core.MergeGroup
+	auth  *core.Auth
 }
 
 func NewSdk() *Sdk {
@@ -32,6 +33,7 @@ func NewSdk() *Sdk {
 func (o *Sdk) NewContext() context.Context {
 	var ctx = context.Background()
 	ctx = core.NewGrouperContext(ctx, o.Group())
+	ctx = core.NewAuthContext(ctx, o.Auth())
 	return ctx
 }
 
@@ -65,4 +67,13 @@ func (o *Sdk) Group() core.Grouper {
 		)
 	}
 	return o.group
+}
+
+func (o *Sdk) Auth() *core.Auth {
+	if o.auth == nil {
+		o.auth = &core.Auth{
+			RefreshToken: "",
+		}
+	}
+	return o.auth
 }

--- a/mgc/sdk/static/static.go
+++ b/mgc/sdk/static/static.go
@@ -30,6 +30,10 @@ func newStatic() *core.StaticExecute {
 					return true, nil
 				})
 			}
+			if auth := core.AuthFromContext(ctx); auth != nil {
+				println("I have auth from context", auth)
+				return nil, nil
+			}
 			return nil, nil
 		},
 	)


### PR DESCRIPTION
## Description

Add authentication context

## Related Issues
- Part of #7 

## Next steps
- Add auth-related configuration properties
- Add build tags for different configurations

## How to test it

- Run: `./cli static static`
- It should show that an Auth context was found
- Remove auth from the Sdk.NewContext function
- Run the command again
- It should show that there is no Auth context