### PR TITLE
[Core] Persists user configuration between command calls

### DIFF
--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -281,10 +281,10 @@ func setSecurityHeader(req *http.Request, auth *core.Auth, secRequirements *open
 	}
 	for _, reqRef := range *secRequirements {
 		for secScheme := range reqRef {
-			if "oauth2" == strings.ToLower(secScheme) {
-				accessToken := auth.AccessToken()
-				if accessToken == "" {
-					return fmt.Errorf("Unauthenticated, run `auth login`")
+			if strings.ToLower(secScheme) == "oauth2" {
+				accessToken, err := auth.AccessToken()
+				if err != nil {
+					return err
 				}
 				req.Header.Set("Authorization", "Bearer "+accessToken)
 				return nil


### PR DESCRIPTION
## Description

Save the user authentication information into a file to persist it between subsequent command calls

## Related Issues
- Closes #59 

## How to test it

With config file:
- Remove Auth env vars
- Run the IDM login
- Check the "~/.mgc.yaml" file for the auth token
- Add a call for auth.AccessToken()
- It should be the same as the file

Without config file:
- Remove config file "~/.mgc.yaml"
- Run `./cli auth login`
- Check for the "~/.mgc.yaml", it should exists

With env var:
- The config file should exist
- Set the MGC_SDK_ACCESS_TOKEN with a different token
- When running a command the auth.AccessToken should return the env var token
