### PR TITLE
feat(operation): add body request

### DIFF
--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -1,7 +1,9 @@
 package openapi
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -229,6 +231,39 @@ func addCookieParam(req *http.Request, param *openapi3.Parameter, val core.Value
 	})
 }
 
+func (o *Operation) createRequestBody(pValues map[string]core.Value) (string, *bytes.Buffer, error) {
+	rbr := o.operation.RequestBody
+	if rbr == nil {
+		return "", bytes.NewBuffer(nil), nil
+	}
+
+	rb := rbr.Value
+	mt := rb.Content.Get("application/json")
+	if mt == nil {
+		// TODO: parse body for multipart and other content types
+		return "", nil, fmt.Errorf("Can not parse body for content type other than application/json")
+	}
+
+	content := mt.Schema.Value
+	if content == nil {
+		return "", nil, fmt.Errorf("Request body with empty schema ref")
+	}
+
+	body := map[string]core.Value{}
+	for pKey, ref := range content.Properties {
+		parameter := ref.Value
+		name := getNameExtension(o.extensionPrefix, parameter.Extensions, pKey)
+		if val, ok := pValues[name]; ok {
+			body[pKey] = val
+		}
+	}
+	bodyBuf := new(bytes.Buffer)
+	if err := json.NewEncoder(bodyBuf).Encode(body); err != nil {
+		return "", nil, fmt.Errorf("Error encoding body content for request: %v", err)
+	}
+	return "application/json", bodyBuf, nil
+}
+
 func (o *Operation) buildRequestFromParams(
 	paramValues map[string]core.Value,
 	configs map[string]core.Value,
@@ -238,10 +273,21 @@ func (o *Operation) buildRequestFromParams(
 		return nil, err
 	}
 
-	req, err := http.NewRequest(strings.ToUpper(o.method), serverURL, nil)
+	httpMethod := strings.ToUpper(o.method)
+	bodyBuf := bytes.NewBuffer(nil)
+	var mimeType string
+	if httpMethod == http.MethodPost || httpMethod == http.MethodPut || httpMethod == http.MethodPatch {
+		mimeType, bodyBuf, err = o.createRequestBody(paramValues)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest(httpMethod, serverURL, bodyBuf)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", mimeType)
 
 	queryValues := url.Values{}
 	for _, ref := range o.operation.Parameters {


### PR DESCRIPTION
## Description

Parse the parameters passed by the user by comparing to the OAPI Schema. Then, add parameters to the body and encode with JSON before adding to request's body.

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

## How to test it

```shell
go run main.go auth login
```

```shell
go run main.go virtual-machine instances post --name "pf-instance-2" --image "cloud-centos-09 LTS" --type "cloud-bs1.xsmall" --key_name "pf-key"
```

```json
{
  "id": "0bb83ff3-e404-40f0-ae28-ac13dd9c2906"
}
```

```shell
go run main.go virtual-machine instances get-id --id 0bb83ff3-e404-40f0-ae28-ac13dd9c2906
```

```json
{
  "availability_zone": null,
  "created_at": "2023-07-28 14:38:53.746537",
  "error": "error creating virtual machine: 400 - tenant:dc44eb47-37f4-4e22-91b9-1bc17f324cda - error:[{\"error_code\": 400, \"message\": \"Invalid key_name provided.\", \"links\": [{\"href\": \"\"}]}]",
  "id": "0bb83ff3-e404-40f0-ae28-ac13dd9c2906",
  "image": {
    "name": "cloud-centos-09 LTS"
  },
  "instance_id": null,
  "instance_type": {
    "name": "cloud-bs1.xsmall"
  },
  "key_name": "pf-key-3",
  "memory": null,
  "name": "pf-instance-3",
  "network_interfaces": [],
  "ports": [
    {
      "id": "0a36d379-8736-422d-8776-92df98847f25"
    }
  ],
  "power_state": null,
  "power_state_label": null,
  "root_storage": null,
  "security_groups": [],
  "status": "error",
  "updated_at": null,
  "vcpus": null,
  "volumes": []
}
```