### PR TITLE
feat: add script validation for content types in OAPI specs

### DIFF
--- a/scripts/spec_stats.py
+++ b/scripts/spec_stats.py
@@ -1,0 +1,137 @@
+import os
+from typing import Dict, Any, List, NamedTuple
+import argparse
+import yaml
+
+OAPISchema = Dict[str, Any]
+OAPIStats = Dict[str, List[Any]]
+
+
+class OAPI(NamedTuple):
+    path: str
+    name: str
+    schema: OAPISchema
+
+
+class ResponseContext(NamedTuple):
+    path: str
+    method: str
+    code: str
+
+
+class OperationContext(NamedTuple):
+    path: str
+    method: str
+
+
+class PathContext(NamedTuple):
+    name: str
+
+
+# This is used to fix list indentations, as Pyyaml doesn't indent them :/
+class YamlDumper(yaml.Dumper):
+    def increase_indent(self, flow=False, indentless=False):
+        return super(YamlDumper, self).increase_indent(flow, False)
+
+
+def load_yaml(path: str) -> OAPISchema:
+    with open(path, "r") as fd:
+        return yaml.load(fd, Loader=yaml.CLoader)
+
+
+def load_oapis(d: str) -> [OAPI]:
+    schemas = []
+    for f in os.listdir(d):
+        name, ext = os.path.splitext(f)
+        if name == "index" or ext != ".yaml":
+            print("ignored file:", f)
+            continue
+
+        path = os.path.join(d, f)
+        schemas.append(OAPI(name=name, path=path, schema=load_yaml(path)))
+
+    return schemas
+
+
+def append(dst: OAPIStats, key: str, val: Any):
+    if not dst.get(key):
+        dst[key] = []
+
+    dst[key].append(val)
+
+
+def fill_responses_stats(ctx: OperationContext, responses: OAPISchema, dst: OAPIStats):
+    key = ctx.method + " " + ctx.path
+    obj = {key: []}
+
+    for code, r in responses.items():
+        content = r.get("content")
+        if not content:
+            # Return for now. In the future check for the code?
+            return
+
+        for t, _ in content.items():
+            if t != "application/json":
+                obj[key].append({code: t})
+
+    if obj[key]:
+        append(dst, "non-json-responses", obj)
+
+
+def fill_req_body_stats(ctx: OperationContext, r: OAPISchema, dst: OAPIStats):
+    content = r.get("content")
+    if content:
+        for t, _ in content.items():
+            if t != "application/json":
+                key = ctx.method + " " + ctx.path
+                append(dst, "non-json-requests", {key: t})
+
+
+def fill_operation_stats(ctx: OperationContext, o: OAPISchema, dst: OAPIStats):
+    responses = o.get("responses")
+    fill_responses_stats(ctx, responses, dst)
+
+    req_body = o.get("requestBody")
+    if req_body:
+        fill_req_body_stats(ctx, req_body, dst)
+
+    return
+
+
+def fill_path_stats(ctx: PathContext, p: OAPISchema, dst: OAPIStats):
+    for method, o in p.items():
+        if isinstance(o, dict) and "operationId" in o:
+            op_ctx = OperationContext(path=ctx.name, method=method)
+            fill_operation_stats(op_ctx, o, dst)
+    return
+
+
+def get_oapi_stats(o: OAPI) -> OAPIStats:
+    result = {}
+
+    for pn, p in o.schema.get("paths", {}).items():
+        ctx = PathContext(name=pn)
+        fill_path_stats(ctx, p, result)
+
+    # TODO: Add stats for other fields
+
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Validate response and request bodies for all OAPI YAML"
+        "files in directory"
+    )
+    parser.add_argument("dir", type=str, help="Directory of OpenAPI files")
+    args = parser.parse_args()
+
+    oapis = load_oapis(args.dir)
+    for o in oapis:
+        stats = get_oapi_stats(o)
+        if stats:
+            print(
+                yaml.dump(
+                    {o.name: stats}, Dumper=YamlDumper, indent=2, allow_unicode=True
+                )
+            )


### PR DESCRIPTION
## Description

This script checks that all contents in request bodies and responses are
of mime-type 'application/json'. It reports otherwise

## Related Issues

- Closes #108

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run with `python3 ./scripts/validate_content_type.py ./mgc/cli/openapis`
