### PR TITLE
feat(config): add config delete command

### DIFF
--- a/mgc/core/config.go
+++ b/mgc/core/config.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"bytes"
 	"context"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 type Config struct{}
@@ -42,10 +44,35 @@ func (c *Config) BindPFlag(key string, flag *pflag.Flag) error {
 	return viper.BindPFlag(key, flag)
 }
 
+func (c *Config) IsSet(key string) bool {
+	return viper.IsSet(key)
+}
+
 func (c *Config) Get(key string) any {
 	return viper.Get(key)
 }
 
 func (c *Config) Set(key string, value interface{}) {
 	viper.Set(key, value)
+}
+
+func (c *Config) Delete(key string) error {
+	configMap := viper.AllSettings()
+
+	delete(configMap, key)
+	encodedConfig, err := yaml.Marshal(configMap)
+	if err != nil {
+		return err
+	}
+
+	err = viper.ReadConfig(bytes.NewReader(encodedConfig))
+	if err != nil {
+		return err
+	}
+
+	if err = viper.WriteConfig(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/mgc/sdk/static/config/config.go
+++ b/mgc/sdk/static/config/config.go
@@ -16,9 +16,10 @@ func NewGroup() *core.StaticGroup {
 		"",
 		"config related commands",
 		[]core.Descriptor{
-			newConfigList(), // cmd: config list
-			newConfigGet(),  // cmd: config get
-			newConfigSet(),  // cmd: config set
+			newConfigList(),   // cmd: config list
+			newConfigGet(),    // cmd: config get
+			newConfigSet(),    // cmd: config set
+			newConfigDelete(), //cmd config delete
 		},
 	)
 }

--- a/mgc/sdk/static/config/config_delete.go
+++ b/mgc/sdk/static/config/config_delete.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"magalu.cloud/core"
+)
+
+type configDeleteParams struct {
+	Key string `jsonschema_description:"Name of the config to be deleted"`
+}
+
+func newConfigDelete() *core.StaticExecute {
+	return core.NewStaticExecute(
+		"delete",
+		"",
+		"Deletes a key from config file",
+		func(ctx context.Context, parameter configDeleteParams, _ struct{}) (result core.Value, err error) {
+			config := core.ConfigFromContext(ctx)
+			if config == nil {
+				return nil, fmt.Errorf("unable to retrieve system configuration")
+			}
+
+			if ok := config.IsSet(parameter.Key); !ok {
+				return nil, fmt.Errorf("no config %s found", parameter.Key)
+			}
+
+			if err := config.Delete(parameter.Key); err != nil {
+				return nil, err
+			}
+
+			return nil, nil
+		},
+	)
+}


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->
## Description

Adds `config delete` command.

Viper does not offer an API to delete or unset keys in the configuration file. Our solution to this problem uses viper to read the configuration file, and store key/value pairs as a `map[string]interface{}` structure. Then viper reads the updated map, and overrides the configuration file with the new data.

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

Closes #85 

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Make sure you have your configuration file set at `$HOME/.mgc/config.yaml`. Ex:

```yaml
region: br-ne-1
verbose: false
````

Running `config delete --key region` should delete the `region` key from the file.

Running the same command again should throw an error, informing that the key was not found