### PR TITLE
chore(examples): CLI example creating VM and Disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ NOTE: One can still use the env var to override the value of the token by settin
 export MGC_SDK_ACCESS_TOKEN=""
 ```
 
+### Examples
+
+Under the folder [examples/](./examples), there are some shell scripts chaining multiple
+CLI requests. For example, to create a VM, create a DISK, and attach both, run:
+
+```shell
+./examples/create-vm-with-disk.sh
+```
+
 
 ## Adding new APIs
 

--- a/examples/create-vm-with-disk.sh
+++ b/examples/create-vm-with-disk.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -xe
+
+cd mgc/cli && go build -o mgc-cli
+
+# 1. Login
+./mgc-cli auth login
+
+# 2. Create Keypair for your SSH, if more than one pub key it will fail
+SSH_KEY_NAME="example-key";
+ssh-keygen -t ed25519 -N "" -f /tmp/$SSH_KEY_NAME
+./mgc-cli virtual-machine keypairs create --name=$SSH_KEY_NAME --public-key="$(cat /tmp/$SSH_KEY_NAME.pub)"
+rm /tmp/$SSH_KEY_NAME
+
+# 3. Create VM
+IMAGE="cloud-debian-11 LTS"
+TYPE="cloud-bs1.xsmall"
+INSTANCE_NAME="vm-example-1"
+read VM_ID < <(./mgc-cli virtual-machine instances create \
+    --image="$IMAGE" \
+    --type=$TYPE \
+    --key_name=$SSH_KEY_NAME \
+    --name=$INSTANCE_NAME -o jsonpath='$.id')
+
+# 4. Create Disk
+DESCRIPTION="example-volume"
+DISK_NAME="example-volume";
+DISK_TYPE="cloud_nvme";
+DISK_SIZE=1;
+read DISK_ID < <(./mgc-cli block-storage volume create \
+    --description=$DESCRIPTION \
+    --name=$DISK_NAME \
+    --volume-type=$DISK_TYPE \
+    --size=$DISK_SIZE -o jsonpath='$.id')
+
+# 5. Wait for the VM to transition to active
+CUR_STATUS=""
+DESIRED_STATUS="ACTIVE"
+while [ [${CUR_STATUS}] != [\"${DESIRED_STATUS}\"] ]
+do
+    CUR_STATUS=$(./mgc-cli virtual-machine instances get --id=$VM_ID 2>/dev/null -o jsonpath='$.status')
+    sleep 1
+done
+
+# 6. Attach Disk to VM - may fail if VM is in Pending status
+./mgc-cli block-storage volume attach \
+    --id=$DISK_ID \
+    --virtual-machine-id=$VM_ID
+
+# 7. Shutoff VM
+./mgc-cli virtual-machine instances update --id=$VM_ID --status="shutoff"

--- a/mgc/cli/openapis/block-storage.openapi.yaml
+++ b/mgc/cli/openapis/block-storage.openapi.yaml
@@ -436,6 +436,7 @@ paths:
             security:
             -   OAuth2:
                 - block-storage.write
+            x-cli-name: attach
     /v0/volumes/{id}/detach/{virtual_machine_id}:
         post:
             tags:
@@ -494,6 +495,7 @@ paths:
             security:
             -   OAuth2:
                 - block-storage.write
+            x-cli-name: detach
 components:
     schemas:
         AttachmentResponse:

--- a/openapi-customizations/block-storage.openapi.yaml
+++ b/openapi-customizations/block-storage.openapi.yaml
@@ -34,6 +34,13 @@ paths:
             x-cli-description: Delete a Block Storage volume
         patch:
             x-cli-description: Update a Block Storage volume
+    /v0/volumes/{id}/attach/{virtual_machine_id}:
+        post:
+            x-cli-name: attach
+    /v0/volumes/{id}/detach/{virtual_machine_id}:
+        post:
+            x-cli-name: detach
+
 
 tags:
 -   name: healthchecks


### PR DESCRIPTION
## Description

Add script chaining operations of the PoC:

1. Login
2. Create SSH Keypair. If more than one pub key it will fail
3. Create VM
4. Create Disk
5. Wait for the VM to transition to active
6. Attach Disk to VM - may fail if VM is in Pending status
7. Shutoff VM

## Related Issues

- Closes #119 

## How to test

```shell
./examples/create-vm-with-disk.sh
```
