### PR TITLE
feat: add dump-tree command

### DIFF
--- a/mgc/cli/cmd/dump_tree.go
+++ b/mgc/cli/cmd/dump_tree.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"magalu.cloud/core"
+	mgcSdk "magalu.cloud/sdk"
+)
+
+func newDumpTreeCmd(sdk *mgcSdk.Sdk) *cobra.Command {
+	return &cobra.Command{
+		Use:   "dump-tree",
+		Short: "Print command tree",
+		Long: `Walks through the command tree, and prints name, description, version, children
+		and schema for parameters and configs`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := sdk.Group()
+
+			tree, err := collectAllChildren(root)
+			if err != nil {
+				return err
+			}
+
+			output := getOutputFlag(cmd)
+			if output == "" {
+				output = "yaml"
+			}
+			name, options := parseOutputFormatter(output)
+			formatter, err := getOutputFormatter(name, options)
+			if err != nil {
+				return err
+			}
+
+			return formatter.Format(tree["children"], options)
+		},
+	}
+}
+
+func collectAllChildren(child core.Descriptor) (map[string]any, error) {
+	node := map[string]any{}
+	node["name"] = child.Name()
+	node["description"] = child.Description()
+	node["version"] = child.Version()
+
+	if executor, ok := child.(core.Executor); ok {
+		node["parameters"] = executor.ParametersSchema()
+		node["configs"] = executor.ConfigsSchema()
+		node["result"] = executor.ResultSchema()
+
+		return node, nil
+	} else if grouper, ok := child.(core.Grouper); ok {
+		children := []map[string]any{}
+		_, err := grouper.VisitChildren(func(child core.Descriptor) (run bool, err error) {
+			c, err := collectAllChildren(child)
+			if err != nil {
+				return false, err
+			}
+			children = append(children, c)
+
+			return true, nil
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("unable to visit all children from node %s: %w", child.Name(), err)
+		}
+
+		node["children"] = children
+
+		return node, nil
+	} else {
+		return nil, fmt.Errorf("child %v not group/executor", child)
+	}
+}

--- a/mgc/cli/cmd/root.go
+++ b/mgc/cli/cmd/root.go
@@ -460,6 +460,8 @@ can generate a command line on-demand for Rest manipulation`,
 
 	sdk := &mgcSdk.Sdk{}
 
+	rootCmd.AddCommand(newDumpTreeCmd(sdk))
+
 	err := DynamicLoadCommand(rootCmd, os.Args[1:], createGroupLoader(sdk, sdk.Group()))
 	if err != nil {
 		rootCmd.PrintErrln("Warning: loading dynamic arguments:", err)


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

Adds `dump-tree` CLI native command. It walks through the command tree, and prints it in the console.
It supports output formatting with `--cli.log/-o` flag. For the `dump-tree` command specifically, if no value
is passed, it formats the output using the yaml formatter.

<!-- Describe what your PR does here, change log, etc -->

## Related Issues
Closes #154 

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run `go run main.go dump-tree` 
