### PR TITLE
refactor: use package logger on `HttpClientLogger`

### DIFF
--- a/mgc/sdk/sdk.go
+++ b/mgc/sdk/sdk.go
@@ -146,9 +146,7 @@ func newHttpTransport() http.RoundTripper {
 		IdleConnTimeout:    30 * time.Second,
 		DisableCompression: true,
 	}
-	if os.Getenv("MGC_SDK_HTTP_LOG") == "1" {
-		transport = core.NewDefaultHttpClientLogger(transport)
-	}
+	transport = core.NewDefaultHttpClientLogger(transport)
 	return transport
 }
 


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

This PR removes Go standard `log` and uses `zap` and `zapfilter` to log HTTP request/response information

## Related Issues
Closes #148 

## Progress

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it
Running the commands bellow should log HTTP request/response related logs

```shell
cd mgc/cli
go run main.go auth login
go run main.go virtual-machine instances list -l "*:*"
```