### PR TITLE
refactor: use sensitive logging in http header

### DIFF
--- a/mgc/core/log_http_headers.go
+++ b/mgc/core/log_http_headers.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type LogHttpHeaders http.Header
+
+func isHeaderSensitive(canonicalKey string) bool {
+	switch canonicalKey {
+	case "Authorization":
+		return true
+	default:
+		return false
+	}
+}
+
+func (h LogHttpHeaders) MarshalJSON() ([]byte, error) {
+	logSensitive := shouldLogSensitive()
+	b := bytes.Buffer{}
+	b.WriteByte('{')
+
+	for key, list := range h {
+		valueListLength := len(list)
+
+		if valueListLength == 0 {
+			continue
+		}
+
+		if b.Len() > 1 {
+			b.WriteByte(',')
+		}
+
+		s, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(s)
+		b.WriteByte(':')
+
+		if !logSensitive && isHeaderSensitive(key) {
+			if valueListLength == 1 {
+				s = ([]byte)(fmt.Sprintf(`"[REDACTED %d CHARS]"`, len(list[0])))
+			} else {
+				s = ([]byte)(fmt.Sprintf(`"[REDACTED %d ENTRIES]"`, valueListLength))
+			}
+		} else {
+			if valueListLength == 1 {
+				s, err = json.Marshal(list[0])
+			} else {
+				s, err = json.Marshal(list)
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		b.Write(s)
+	}
+
+	b.WriteByte('}')
+	return b.Bytes(), nil
+}

--- a/mgc/core/log_sensitive.go
+++ b/mgc/core/log_sensitive.go
@@ -1,0 +1,32 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type LogSensitive string
+
+const logSensitiveEnvVar = "MGC_SDK_LOG_SENSITIVE"
+
+var shouldLogSensitveStatus *bool
+
+func shouldLogSensitive() bool {
+	if shouldLogSensitveStatus == nil {
+		b := os.Getenv(logSensitiveEnvVar) == "1"
+		shouldLogSensitveStatus = &b
+	}
+	return *shouldLogSensitveStatus
+}
+
+func (s LogSensitive) MarshalJSON() ([]byte, error) {
+	var text string
+	if shouldLogSensitive() {
+		text = string(s)
+	} else {
+		text = fmt.Sprintf("[REDACTED %d CHARS]", len(s))
+	}
+
+	return json.Marshal(text)
+}


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

This PR adds the `LogHttpHeaders` type to log http headers in structured manner, and redact sensitive information.

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

- Closes #176 

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run the following to run **WITHOUT** redaction:

```shell
cd mgc/cli
export MGC_SDK_LOG_SENSITIVE=1
go run main.go virtual-machine instances list -l "*:*"
```

Run the following to run **WITH** redaction:

```shell
cd mgc/cli
export MGC_SDK_LOG_SENSITIVE=0
go run main.go virtual-machine instances list -l "*:*"
```

Example of redacted log:

```
2023-08-17T15:43:50.687-0300	DEBUG	mgc.magalu.cloud/core.http	core/http_logger.go:46	request header info	{"method": "GET", "url": "https://api-virtual-machine.br-ne-1.jaxyendy.com/v0/instances", "protocol": "HTTP/1.1", "headers": {"Accept":"*/*","Accept-Encoding":"gzip, deflate, br","Connection":"keep-alive","Authorization":"[REDACTED 1190 CHARS]"}}
```