### PR TITLE
chore(openapi): override nullable fields in vm

### DIFF
--- a/mgc/cli/openapis/virtual-machine.openapi.yaml
+++ b/mgc/cli/openapis/virtual-machine.openapi.yaml
@@ -786,6 +786,7 @@ components:
                     title: Instance Id
                     type: string
                     format: uuid
+                    nullable: true
                 name:
                     title: Name
                     type: string
@@ -796,18 +797,23 @@ components:
                 vcpus:
                     title: Vcpus
                     type: integer
+                    nullable: true
                 memory:
                     title: Memory
                     type: integer
+                    nullable: true
                 root_storage:
                     title: Root Storage
                     type: integer
+                    nullable: true
                 power_state:
                     title: Power State
                     type: integer
+                    nullable: true
                 power_state_label:
                     title: Power State Label
                     type: string
+                    nullable: true
                 status:
                     title: Status
                     type: string
@@ -817,12 +823,14 @@ components:
                 updated_at:
                     title: Updated At
                     type: string
+                    nullable: true
                 key_name:
                     title: Key Name
                     type: string
                 availability_zone:
                     title: Availability Zone
                     type: string
+                    nullable: true
                 volumes:
                     title: Volumes
                     type: array
@@ -846,6 +854,7 @@ components:
                 error:
                     title: Error
                     type: string
+                    nullable: true
             example:
                 id: 76e3b8c4-407f-422b-a1e9-343a40faf1cd
                 instance_id: 176f2b61-306e-4d6f-977d-b9d5bf916322
@@ -1250,6 +1259,7 @@ components:
                 id:
                     title: Id
                     type: string
+                    nullable: true
                 name:
                     title: Name
                     type: string

--- a/openapi-customizations/virtual-machine.openapi.yaml
+++ b/openapi-customizations/virtual-machine.openapi.yaml
@@ -50,3 +50,30 @@ tags:
     description: images
 -   name: usage
     description: usage
+
+components:
+    schemas:
+        SecurityGroup:
+            properties:
+                id:
+                    nullable: true
+        InstanceResponse:
+            properties:
+                instance_id:
+                    nullable: true
+                vcpus:
+                    nullable: true
+                memory:
+                    nullable: true
+                root_storage:
+                    nullable: true
+                power_state:
+                    nullable: true
+                power_state_label:
+                    nullable: true
+                updated_at:
+                    nullable: true
+                availability_zone:
+                    nullable: true
+                error:
+                    nullable: true


### PR DESCRIPTION
## Description

Some fields are nullable and are wrong in the spec. MGC just updated their Virtual Machine schema adding the nullable fields. However, it changed many other properties that are breaking the behavior, thus I'm choosing to add this partial fix as an override/customization