### PR TITLE
feat(ft): use refresh token instead of access token

### DIFF
--- a/mgc/terraform-provider-mgc/examples/provider/main.tf
+++ b/mgc/terraform-provider-mgc/examples/provider/main.tf
@@ -7,16 +7,7 @@ terraform {
     }
 }
 
-// TODO: For now I'm setting this up with the env var TF_VAR_access_token
-// it's not working through the terminal in my laptop
-variable "access_token" {
-    sensitive = true
-    type = string
-    description = "Token used when authenticating in the MagaluCloud"
-}
-
 provider "magalu" {
-    api_key = var.access_token
     # This will be used later on to test the SDK loading functions
     apis = ["virtual-machine@1.60.0"]
 }


### PR DESCRIPTION
## Description

The usage of the refresh token makes easier for the user to use the terraform provider without the need of every 15min to find a new access token, update the environment variable and the execute the terraform action.

## Progress

- [ ] Test using the endpoints (VPN is down right now)
