### PR TITLE
fix(cli): ignore optional values

### DIFF
--- a/mgc/cli/cmd/root.go
+++ b/mgc/cli/cmd/root.go
@@ -150,13 +150,17 @@ func loadDataFromFlags(flags *flag.FlagSet, schema *mgcSdk.Schema, dst map[strin
 		return fmt.Errorf("invalid command or parameter schema")
 	}
 
-	for name := range schema.Properties {
+	for name, propRef := range schema.Properties {
+		propSchema := propRef.Value
 		val, flag, err := getFlagValue(flags, name)
 		if flag == nil {
 			continue
 		}
 		if err != nil {
 			return err
+		}
+		if val == nil && !(propSchema.Nullable || propSchema.Type == "null") {
+			continue
 		}
 		dst[name] = val
 	}


### PR DESCRIPTION
## Description

We are using null as a "default" value for optional values which broke some requests since some of those values required a specific type when provided.

Now if the paramenter is optional or non-nullable we remove it from the parameters list in case the user didn't provide any values.

## How to test it

Try to create a virtual machine with the CLI using only the required elements parameters