### PR TITLE
fix(cli): user defined output takes precedence over oapi one

### DIFF
--- a/mgc/cli/cmd/root.go
+++ b/mgc/cli/cmd/root.go
@@ -235,10 +235,14 @@ func handleJsonResult(exec mgcSdk.Executor, result core.Value, output string) (e
 }
 
 func getOutputFor(cmd *cobra.Command, exec core.Executor, result core.Value) string {
-	if outputOptions, ok := exec.(core.ExecutorResultOutputOptions); ok {
-		return outputOptions.DefaultOutputOptions(result)
+	output := getOutputFlag(cmd)
+	if output == "" {
+		if outputOptions, ok := exec.(core.ExecutorResultOutputOptions); ok {
+			return outputOptions.DefaultOutputOptions(result)
+		}
 	}
-	return getOutputFlag(cmd)
+
+	return output
 }
 
 func AddAction(


### PR DESCRIPTION
## Description

We were always using the output defined in the OAPI spec, even when the user requested a different output. Now we only use the OAPI default output in case the output format isn't defined by the user.

## How to test it

- Define an output format in the OAPI spec using:
    - `x-cli-output-options: table=NAME:$.instances[*].name,ID:$.instances[*].id`
    - `x-cli-output-flag: table=NAME:$.instances[*].name,ID:$.instances[*].id`
- Run the command it should display in the table format
- Add `-o json` flag and it should display in json

