### PR TITLE
fix(terraform): fix logic of deciding computed/non-computed input attributes

### DIFF
--- a/mgc/terraform-provider-mgc/internal/provider/schema.go
+++ b/mgc/terraform-provider-mgc/internal/provider/schema.go
@@ -137,7 +137,7 @@ func getInputChildModifiers(mgcSchema *mgcSdk.Schema, mgcName mgcName) attribute
 	return attributeModifiers{
 		isRequired:                 isRequired,
 		isOptional:                 !isRequired,
-		isComputed:                 !isRequired,
+		isComputed:                 false, // This is being set to false because the parent may already be Computed, no further logic is needed here
 		useStateForUnknown:         true,
 		requiresReplaceWhenChanged: false,
 		getChildModifiers:          getInputChildModifiers,
@@ -147,10 +147,21 @@ func getInputChildModifiers(mgcSchema *mgcSdk.Schema, mgcName mgcName) attribute
 func (r *MgcResource) getCreateParamsModifiers(mgcSchema *mgcSdk.Schema, mgcName mgcName) attributeModifiers {
 	k := string(mgcName)
 	isRequired := slices.Contains(mgcSchema.Required, k)
+	isComputed := !isRequired
+	if isComputed {
+		readSchema := r.read.ResultSchema().Properties[k]
+		if readSchema == nil {
+			isComputed = false
+		} else {
+			// If not required and present in read it can be compute
+			isComputed = checkSimilarJsonSchemas((*core.Schema)(readSchema.Value), (*core.Schema)(mgcSchema.Properties[string(mgcName)].Value))
+		}
+	}
+
 	return attributeModifiers{
 		isRequired:                 isRequired,
 		isOptional:                 !isRequired,
-		isComputed:                 !isRequired && r.read.ResultSchema().Properties[k] != nil, // If not required and present in read it can be compute
+		isComputed:                 isComputed,
 		useStateForUnknown:         false,
 		requiresReplaceWhenChanged: r.update.ParametersSchema().Properties[k] == nil,
 		getChildModifiers:          getInputChildModifiers,
@@ -161,10 +172,12 @@ func (r *MgcResource) getUpdateParamsModifiers(mgcSchema *mgcSdk.Schema, mgcName
 	k := string(mgcName)
 	isCreated := r.create.ResultSchema().Properties[k] != nil
 	required := slices.Contains(mgcSchema.Required, k)
+	isComputed := !required || isCreated
+
 	return attributeModifiers{
 		isRequired:                 required && !isCreated,
 		isOptional:                 !required && !isCreated,
-		isComputed:                 !required || isCreated,
+		isComputed:                 isComputed,
 		useStateForUnknown:         true,
 		requiresReplaceWhenChanged: false,
 		getChildModifiers:          getInputChildModifiers,

--- a/mgc/terraform-provider-mgc/internal/provider/schema_test.go
+++ b/mgc/terraform-provider-mgc/internal/provider/schema_test.go
@@ -124,7 +124,7 @@ var testCases = []testCase{
 				tfSchema: schema.NumberAttribute{
 					Description:   "count description",
 					Optional:      true,
-					Computed:      true,
+					Computed:      false, // False because read result attr has different schema
 					PlanModifiers: []planmodifier.Number{},
 				},
 			},
@@ -137,14 +137,14 @@ var testCases = []testCase{
 						Attributes: map[string]schema.Attribute{
 							"value": schema.BoolAttribute{
 								Optional: true,
-								Computed: true,
+								Computed: false,
 								PlanModifiers: []planmodifier.Bool{
 									boolplanmodifier.UseStateForUnknown(),
 								},
 							},
 						},
 						Optional: true,
-						Computed: true,
+						Computed: false,
 						PlanModifiers: []planmodifier.Object{
 							objectplanmodifier.UseStateForUnknown(),
 						},
@@ -164,14 +164,14 @@ var testCases = []testCase{
 							Attributes: map[string]schema.Attribute{
 								"value": schema.BoolAttribute{
 									Optional: true,
-									Computed: true,
+									Computed: false,
 									PlanModifiers: []planmodifier.Bool{
 										boolplanmodifier.UseStateForUnknown(),
 									},
 								},
 							},
 							Optional: true,
-							Computed: true,
+							Computed: false,
 							PlanModifiers: []planmodifier.Object{
 								objectplanmodifier.UseStateForUnknown(),
 							},
@@ -183,7 +183,7 @@ var testCases = []testCase{
 								mgcSchema: (*mgc.Schema)(update.ParametersSchema().Properties["extra_field"].Value.Items.Value.Properties["value"].Value),
 								tfSchema: schema.BoolAttribute{
 									Optional: true,
-									Computed: true,
+									Computed: false,
 									PlanModifiers: []planmodifier.Bool{
 										boolplanmodifier.UseStateForUnknown(),
 									},
@@ -245,18 +245,18 @@ var testCases = []testCase{
 					NestedObject: schema.SingleNestedAttribute{
 						Attributes: map[string]schema.Attribute{
 							"value": schema.BoolAttribute{
-								Computed: true,
+								Computed: false,
 								PlanModifiers: []planmodifier.Bool{
 									boolplanmodifier.UseStateForUnknown(),
 								},
 							},
 						},
-						Computed: true,
+						Computed: false,
 						PlanModifiers: []planmodifier.Object{
 							objectplanmodifier.UseStateForUnknown(),
 						},
 					}.GetNestedObject().(schema.NestedAttributeObject),
-					Computed: true,
+					Computed: false,
 					PlanModifiers: []planmodifier.List{
 						listplanmodifier.UseStateForUnknown(),
 					},
@@ -339,7 +339,7 @@ var testCases = []testCase{
 			},
 			"desired_count": schema.NumberAttribute{
 				Optional:      true,
-				Computed:      true,
+				Computed:      false,
 				Description:   "count description",
 				PlanModifiers: []planmodifier.Number{},
 			},
@@ -348,14 +348,14 @@ var testCases = []testCase{
 					Attributes: map[string]schema.Attribute{
 						"value": schema.BoolAttribute{
 							Optional: true,
-							Computed: true,
+							Computed: false,
 							PlanModifiers: []planmodifier.Bool{
 								boolplanmodifier.UseStateForUnknown(),
 							},
 						},
 					},
 					Optional: true,
-					Computed: true,
+					Computed: false,
 					PlanModifiers: []planmodifier.Object{
 						objectplanmodifier.UseStateForUnknown(),
 					},
@@ -396,6 +396,7 @@ func TestGenerateTFAttributes(t *testing.T) {
 	ctx := context.Background()
 	// Use deep.Equal because we might compare two functions, and reflect.DeepEqual always fails on function
 	// comparisons (unless both functions are nil)
+	// TODO: investigate lib reporting false negatives/positives on deep comparisons...
 	for _, testCase := range testCases {
 		testCase.res.readInputAttributes(ctx)
 		if diff := deep.Equal(testCase.res.inputAttr, testCase.expectedInput); diff != nil {


### PR DESCRIPTION
## Description

When attributes are split between `desired` and `current`, the `desired` one should NEVER be computed

## Related Issues

- Closes #237

