### PR TITLE
feat(s3): objects download

### DIFF
--- a/mgc/sdk/static/object_storage/objects/download.go
+++ b/mgc/sdk/static/object_storage/objects/download.go
@@ -1,0 +1,206 @@
+package objects
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"go.uber.org/zap"
+	"magalu.cloud/core"
+	"magalu.cloud/sdk/static/object_storage/s3"
+)
+
+var downloadObjectsLogger *zap.SugaredLogger
+
+func downloadLogger() *zap.SugaredLogger {
+	if downloadObjectsLogger == nil {
+		downloadObjectsLogger = logger().Named("download")
+	}
+	return downloadObjectsLogger
+}
+
+type downloadObjectsError struct {
+	errorMap map[string]error
+}
+
+func (o downloadObjectsError) Error() string {
+	var errorMsg string
+	for file, err := range o.errorMap {
+		errorMsg += fmt.Sprintf("%s - %s, ", file, err)
+	}
+	// Remove trailing `, `
+	if len(errorMsg) != 0 {
+		errorMsg = errorMsg[:len(errorMsg)-2]
+	}
+	return fmt.Sprintf("failed to download some objects from bucket: %s", errorMsg)
+}
+
+func (o downloadObjectsError) Add(uri string, err error) {
+	o.errorMap[uri] = err
+}
+
+func (o downloadObjectsError) HasError() bool {
+	return len(o.errorMap) != 0
+}
+
+func NewDownloadObjectsError() downloadObjectsError {
+	return downloadObjectsError{
+		errorMap: make(map[string]error),
+	}
+}
+
+type downloadObjectParams struct {
+	Source      string `json:"src" jsonschema:"description=Path of the object to be downloaded" example:"s3://bucket1/file1"`
+	Destination string `json:"dst,omitempty" jsonschema:"description=Name of the file to be saved" example:"file1.txt"`
+}
+
+func newDownload() core.Executor {
+	executor := core.NewStaticExecute(
+		"download",
+		"",
+		"download an object from a bucket",
+		download,
+	)
+
+	return core.NewExecuteResultOutputOptions(executor, func(exec core.Executor, result core.Value) string {
+		return "template=Downloaded from {{.src}} to {{.dst}}\n"
+	})
+}
+
+func newDownloadRequest(ctx context.Context, region string, pathURIs ...string) (*http.Request, error) {
+	host := s3.BuildHost(region)
+	url, err := url.JoinPath(host, pathURIs...)
+	if err != nil {
+		return nil, err
+	}
+	return http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+}
+
+func writeToFile(reader io.ReadCloser, outFile string) (err error) {
+	defer reader.Close()
+
+	writer, err := os.OpenFile(outFile, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+
+	n, err := writer.ReadFrom(reader)
+	defer writer.Close()
+	if err != nil {
+		return fmt.Errorf("error writing to file (wrote %d bytes): %w", n, err)
+	}
+	return nil
+}
+
+func downloadSingleFile(ctx context.Context, cfg s3.Config, src, dst string) error {
+	bucketURI, _ := strings.CutPrefix(src, s3.URIPrefix)
+	downloadLogger().Infof("Downloading %s", bucketURI)
+	req, err := newDownloadRequest(ctx, cfg.Region, bucketURI)
+	if err != nil {
+		return err
+	}
+
+	var closer io.ReadCloser
+	data, err := s3.SendRequest(ctx, req, cfg.AccessKeyID, cfg.SecretKey, &closer)
+	if err != nil {
+		return err
+	}
+
+	if !isFilePath(dst) {
+		_, fname := path.Split(bucketURI)
+		dst = path.Join(dst, fname)
+	}
+
+	dir, _ := path.Split(dst)
+	if err := os.MkdirAll(dir, core.FILE_PERMISSION); err != nil {
+		return err
+	}
+
+	if err := writeToFile(data, dst); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downloadMultipleFiles(ctx context.Context, cfg s3.Config, src, dst string) error {
+	bucketURI, _ := strings.CutPrefix(src, s3.URIPrefix)
+	bucketName := strings.Split(bucketURI, "/")[0]
+	objs, err := List(ctx, ListObjectsParams{Destination: bucketURI}, cfg)
+	if err != nil {
+		return err
+	}
+
+	objError := NewDownloadObjectsError()
+	for _, obj := range objs.Contents {
+		objURI := path.Join(bucketName, obj.Key)
+		downloadLogger().Infof("Downloading %s", objURI)
+		req, err := newDownloadRequest(ctx, cfg.Region, objURI)
+		if err != nil {
+			objError.Add(objURI, err)
+			continue
+		}
+
+		var closer io.ReadCloser
+		data, err := s3.SendRequest(ctx, req, cfg.AccessKeyID, cfg.SecretKey, &closer)
+		if err != nil || data == nil {
+			objError.Add(objURI, err)
+			continue
+		}
+
+		dir, _ := path.Split(obj.Key)
+		if err := os.MkdirAll(path.Join(dst, dir), core.FILE_PERMISSION); err != nil {
+			objError.Add(objURI, err)
+			continue
+		}
+
+		if err := writeToFile(data, path.Join(dst, obj.Key)); err != nil {
+			objError.Add(objURI, err)
+			continue
+		}
+	}
+
+	if objError.HasError() {
+		return objError
+	}
+
+	return nil
+}
+
+func isFilePath(fpath string) bool {
+	// TODO: find a better way to infer if it's a file - requesting metadata to s3?
+	return path.Ext(fpath) != ""
+}
+
+func download(ctx context.Context, p downloadObjectParams, cfg s3.Config) (result core.Value, err error) {
+	dst := p.Destination
+	if dst == "" {
+		dst, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("no destination specified and could not use local dir: %w", err)
+		}
+		_, fname := path.Split(p.Source)
+		dst = path.Join(dst, fname)
+	}
+	if isFilePath(p.Source) {
+		// User specified a directory, append the file name to it
+		if !isFilePath(dst) {
+			_, fname := path.Split(p.Source)
+			dst = path.Join(dst, fname)
+		}
+		err = downloadSingleFile(ctx, cfg, p.Source, dst)
+	} else {
+		err = downloadMultipleFiles(ctx, cfg, p.Source, dst)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return downloadObjectParams{Source: p.Source, Destination: dst}, nil
+}

--- a/mgc/sdk/static/object_storage/objects/group.go
+++ b/mgc/sdk/static/object_storage/objects/group.go
@@ -10,9 +10,10 @@ func NewGroup() core.Grouper {
 		"",
 		"Object operations for Object Storage API",
 		[]core.Descriptor{
-			newDelete(), // object-storage objects delete
-			newList(),   // object-storage objects list
-			newUpload(), // object-storage objects upload
+			newDelete(),   // object-storage objects delete
+			newDownload(), // object-storage objects download
+			newList(),     // object-storage objects list
+			newUpload(),   // object-storage objects upload
 		},
 	)
 }

--- a/mgc/sdk/static/object_storage/objects/logger.go
+++ b/mgc/sdk/static/object_storage/objects/logger.go
@@ -1,0 +1,17 @@
+package objects
+
+import (
+	"go.uber.org/zap"
+	corelogger "magalu.cloud/core/logger"
+)
+
+type pkgSymbol struct{}
+
+var pkgLogger *zap.SugaredLogger
+
+func logger() *zap.SugaredLogger {
+	if pkgLogger == nil {
+		pkgLogger = corelogger.New[pkgSymbol]()
+	}
+	return pkgLogger
+}


### PR DESCRIPTION
## Description

Added `objects download` command that will download either a single object or all objects from a bucket:

1. Single file: `go run main.go -l "info:*" --access-key-id=$ACCESS_KEY --secret-key=$SECRET_KEY object-storage objects download --src s3://bucket1/a.txt`

Saves to `./a.txt`

2. Multiple files: 

```shell
./mgc --access-key-id=$ACCESS_KEY --secret-key=$SECRET_KEY object-storage objects list --dst s3://bucket1 -o yaml
Contents:
    - Key: a.txt
      LastModified: "2023-09-08T17:22:13.986Z"
      Size: 18
    - Key: subdir1/c.txt
      LastModified: "2023-09-08T16:23:41.256Z"
      Size: 18
    - Key: subdir1/hello.txt
      LastModified: "2023-09-08T16:23:56.313Z"
      Size: 18
    - Key: subdir2/b.txt
      LastModified: "2023-09-08T17:22:24.823Z"
      Size: 18
Name: bucket1
```

Then:

```shell
$ go run main.go -l "info:*" --access-key-id=$ACCESS_KEY --secret-key=$SECRET_KEY object-storage objects download --src s3://bucket1 --dst ./tmp
INFO	magalu.cloud/sdk/static/object_storage/objects.download	Downloading bucket1/a.txt
INFO	magalu.cloud/sdk/static/object_storage/objects.download	Downloading bucket1/subdir1/c.txt
INFO	magalu.cloud/sdk/static/object_storage/objects.download	Downloading bucket1/subdir1/hello.txt
INFO	magalu.cloud/sdk/static/object_storage/objects.download	Downloading bucket1/subdir2/b.txt
Downloaded from s3://bucket1 to ./tmp

$ find ./tmp
./tmp
./tmp/subdir2
./tmp/subdir2/b.txt
./tmp/a.txt
./tmp/subdir1
./tmp/subdir1/c.txt
./tmp/subdir1/hello.txt
```