### PR TITLE
refactor: log diverging config warn with logger

### DIFF
--- a/mgc/sdk/static/config/list.go
+++ b/mgc/sdk/static/config/list.go
@@ -6,9 +6,19 @@ import (
 	"reflect"
 
 	"github.com/jedib0t/go-pretty/v6/table"
+	"go.uber.org/zap"
 	"magalu.cloud/core"
 	"magalu.cloud/core/config"
 )
+
+var listLoggerInstance *zap.SugaredLogger
+
+func listLogger() *zap.SugaredLogger {
+	if listLoggerInstance == nil {
+		listLoggerInstance = logger().Named("list")
+	}
+	return listLoggerInstance
+}
 
 func configListFormatter(result core.Value) string {
 	configMap := result.(map[string]any) // it must be this, assert
@@ -56,7 +66,7 @@ func getAllConfigs(ctx context.Context) (map[string]*core.Schema, error) {
 
 			if existing, ok := configMap[name]; ok {
 				if !reflect.DeepEqual(existing, current) {
-					fmt.Printf("WARNING: unhandled diverging config at %v %v: %v != %v\n", path, name, existing, current)
+					listLogger().Warnw("unhandled diverging config", "config", name, "path", path, "current", current, "existing", existing)
 				}
 
 				continue

--- a/mgc/sdk/static/config/logger.go
+++ b/mgc/sdk/static/config/logger.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"go.uber.org/zap"
+	corelogger "magalu.cloud/core/logger"
+)
+
+type pkgSymbol struct{}
+
+var pkgLogger *zap.SugaredLogger
+
+func logger() *zap.SugaredLogger {
+	if pkgLogger == nil {
+		pkgLogger = corelogger.New[pkgSymbol]()
+	}
+	return pkgLogger
+}


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

Unhandled diverging configs were being logged with `fmt.Println()`. We should log them with our own logger to allow structured logging and filtering.

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

- Closes #209 

## Progress

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

