### PR TITLE
Add check for single item xOf on openapi files

### DIFF
--- a/scripts/spec_stats.py
+++ b/scripts/spec_stats.py
@@ -439,8 +439,12 @@ def load_oapis(dir_or_path: str, ignore_disabled: bool) -> List[OAPI]:
         result = []
         for f in os.listdir(d):
             path = os.path.join(d, f)
+            # Prevent file loading, save resources
+            if ignore_disabled and ".disabled" in path:
+                continue
+
             oapi = load_oapi(path)
-            if not oapi or (ignore_disabled and ".disabled" in path):
+            if not oapi:
                 continue
 
             result.append(oapi)


### PR DESCRIPTION
## Description

Adds check and feedback related to when `allOf`, `anyOf` and `oneOf` keys have a single item.

## Related Issues
- Closes #233 

## Progress
- [x] New checks created;
- [x] Test;

### Pull request checklist

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [x] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it
1. Create a file or edit an existing one so it has code similar to this either on a `requestBody` or in a `response > ... > content` (recomended file is: `mgc/cli/openapis/block-storage.openapi.yaml`)
```
                content:
                    application/json:
                        schema:
                            oneOf:
                                - $ref: '#/components/schemas/VolumeTypeRequest'
```
2. Run `python3 ./scripts/spec_stats.py ./path/to/file`
3. In the logged results, the path should appear, showing if it was the request, response and which response code body it has a problem in which xOf key. Example:
```
  xof-single-item:
    POST /v0/volume_types:
      request:
        - oneOf
      response:
        '201':
          - allOf
        '422':
          - anyOf
```
