### PR TITLE
feat(tf): add updatable hints to oapi operation params

### DIFF
--- a/mgc/cli/openapis/virtual-machine.openapi.yaml
+++ b/mgc/cli/openapis/virtual-machine.openapi.yaml
@@ -818,12 +818,14 @@ components:
                     type: string
                     x-cli-transforms:
                     -   type: lowercase
+                    x-cli-updatable: true
                 created_at:
                     title: Created At
                     type: string
                 updated_at:
                     title: Updated At
                     type: string
+                    x-cli-updatable: true
                 key_name:
                     title: Key Name
                     type: string
@@ -853,6 +855,7 @@ components:
                 error:
                     title: Error
                     type: string
+                    x-cli-updatable: true
             example:
                 id: 76e3b8c4-407f-422b-a1e9-343a40faf1cd
                 instance_id: 176f2b61-306e-4d6f-977d-b9d5bf916322

--- a/openapi-customizations/virtual-machine.openapi.yaml
+++ b/openapi-customizations/virtual-machine.openapi.yaml
@@ -54,6 +54,12 @@ components:
                 status:
                     x-cli-transforms:
                     -   type: lowercase
+                updated_at:
+                    x-cli-updatable: true
+                status:
+                    x-cli-updatable: true
+                error:
+                    x-cli-updatable: true
 
 tags:
 -   name: instances


### PR DESCRIPTION
## Description

Params that can change between read or update operations can be flagged as updatable, this way the `terraform plan` command will show a more succinct output with just possible changes.

## How to test it

- Create a VM instance resource
- Update VM status inside the resource
- `terraform plan` should display only values that can change between updates
