### PR TITLE
Add scanner to splitUnquoted implementation

### DIFF
--- a/mgc/cli/cmd/output_table_test.go
+++ b/mgc/cli/cmd/output_table_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestSplitUnquoted(t *testing.T) {
+	testCases := []struct {
+		in  string
+		out []string
+	}{
+		{`a:b`, []string{"a", "b"}},
+		{`a":b"`, []string{"a:b"}},
+		{`"a:b"`, []string{"a:b"}},
+		{`"a":"b"`, []string{"a", "b"}},
+		{`"a:\"b"`, []string{`a:"b`}},
+		{``, []string{}},
+	}
+	for _, tc := range testCases {
+		t.Run(
+			fmt.Sprintf("Convert \"%s\" to %#v", tc.in, tc.out),
+			func(t *testing.T) {
+				result, err := splitUnquoted(tc.in, ":")
+				if err != nil {
+					t.Errorf("Expected function to work, found error: %v", err)
+					return
+				}
+				if !reflect.DeepEqual(tc.out, result) {
+					t.Errorf("Convesion failed: for input %s, expected %#v, got %#v", tc.in, tc.out, result)
+				}
+			},
+		)
+	}
+}
+
+func TestSplitUnquotedShoudlFail(t *testing.T) {
+	testCases := []string{
+		`a:"b`,
+		`"a:b`,
+	}
+	for _, tc := range testCases {
+		t.Run(
+			fmt.Sprintf("Should fail to convert \"%s\"", tc),
+			func(t *testing.T) {
+				_, err := splitUnquoted(tc, ":")
+				if err == nil {
+					t.Error("Function should error and did not")
+					return
+				}
+				if !errors.Is(err, strconv.ErrSyntax) {
+					t.Errorf("Expected %v, found %v", strconv.ErrSyntax, err)
+				}
+			},
+		)
+	}
+}


### PR DESCRIPTION
## Description

Changes implementation of `splitUnquoted` to use `text/scanner` go library.

## Related Issues
No related issues

## Progress

- [x] Mock implementation;
- [x] Validate team tests;
- [x] Check build when substituting original implementation;

### Pull request checklist

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [x] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

```bash
cd mgc/cli/cmd

go test
```
