### PR TITLE
Lower file permissions when reading/writting files

### DIFF
--- a/mgc/core/config/config.go
+++ b/mgc/core/config/config.go
@@ -90,7 +90,7 @@ func (c *Config) Get(key string) any {
 }
 
 func (c *Config) Set(key string, value interface{}) error {
-	if err := os.MkdirAll(path.Dir(c.path), core.FILE_PERMISSION); err != nil {
+	if err := os.MkdirAll(path.Dir(c.path), core.DIR_PERMISSION); err != nil {
 		return fmt.Errorf("error creating dir at %s: %w", c.path, err)
 	}
 	c.viper.Set(key, value)
@@ -123,7 +123,7 @@ func (c *Config) saveToConfigFile(configMap map[string]interface{}) error {
 		return err
 	}
 
-	if err = c.fs.MkdirAll(path.Dir(c.path), core.FILE_PERMISSION); err != nil {
+	if err = os.MkdirAll(path.Dir(c.path), core.DIR_PERMISSION); err != nil {
 		return fmt.Errorf("error creating dir at %s: %w", c.path, err)
 	}
 

--- a/mgc/core/util.go
+++ b/mgc/core/util.go
@@ -8,7 +8,9 @@ import (
 	"runtime"
 )
 
-const FILE_PERMISSION = 0777 // TODO: investigate how to lower permission
+// These two const are needed because only 07xx (executable) directories can be accessed
+const FILE_PERMISSION = 0644
+const DIR_PERMISSION = 0744
 
 // Copied code from https://pkg.go.dev/os#UserConfigDir but modified to treat
 // Darwin the same way as Unix by setting to "~/.config"
@@ -34,7 +36,7 @@ func BuildMGCPath() (string, error) {
 		}
 	}
 	mgcDir := path.Join(dir, "mgc")
-	if err := os.MkdirAll(mgcDir, FILE_PERMISSION); err != nil {
+	if err := os.MkdirAll(mgcDir, DIR_PERMISSION); err != nil {
 		return "", fmt.Errorf("Error creating mgc dir at %s: %w", mgcDir, err)
 	}
 	return mgcDir, nil
@@ -45,7 +47,7 @@ func BuildMGCFilePath(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := os.MkdirAll(mgcDir, FILE_PERMISSION); err != nil {
+	if err := os.MkdirAll(mgcDir, DIR_PERMISSION); err != nil {
 		return "", fmt.Errorf("Error creating mgc dir at %s: %w", mgcDir, err)
 	}
 	return path.Join(mgcDir, filename), nil


### PR DESCRIPTION
## Description

Permissions for writting files were set to max (inclusing execute) for it would report `permission denied` otherwise.

Turns out that directories need execute permissions to create files, so two permission levels are needed:
- Directory permissions: 0744 (execute permission for user, just read otherwise)
- File permissions: 0644 (no need for execute permissions)

## Related Issues
No related issues

## Progress

- [x] Separate permissions
- [x] Consult code to change permissions to new format where needed
- [x] Test file creation and reading

### Pull request checklist

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [x] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Application should keep running as intended previously.

Commands to test:
- `./mgc config set --key region --value br-ne-2`
- `./mgc config get --key region` -> Output: `br-ne-2`
