### PR TITLE
fix: getCoalescedPath condition and getServerURL with no server variables

### DIFF
--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -777,6 +777,13 @@ func (o *Operation) addServerVariables(schema *core.Schema) {
 }
 
 func (o *Operation) getServerURL(configs core.Configs) (string, error) {
+	if len(o.servers) == 0 {
+		return "", fmt.Errorf("no available servers in spec")
+	}
+	if len(o.servers[0].Variables) == 0 {
+		return o.servers[0].URL, nil
+	}
+
 	url := ""
 	_, err := o.forEachServerVariable(func(externalName, internalName string, spec *openapi3.ServerVariable, server *openapi3.Server) (run bool, err error) {
 		val, ok := configs[externalName]

--- a/mgc/sdk/openapi/resource.go
+++ b/mgc/sdk/openapi/resource.go
@@ -149,9 +149,9 @@ func getPathEntry(pathEntry string) (string, bool) {
 func getCoalescedPath(path []operationTreePath) []string {
 	parts := []string{}
 	wasVariable := false
-	for _, p := range path {
+	for i, p := range path {
 		pathEntry, isVariable := getPathEntry(p.key)
-		if len(p.parent.tree) > 1 || wasVariable {
+		if i == 0 || len(p.parent.tree) > 1 || wasVariable {
 			parts = append(parts, pathEntry)
 		}
 		wasVariable = isVariable


### PR DESCRIPTION
## Description

Two bugs have been fixed:

- The `getCoalescedPath` function at `mgc/sdk/openapi/resource.go` has an issue with the `len(p.parent.tree) > 1` check. If you define an OpenAPI schema with a single command (see example below), this check will never pass as there's no branching path, so `len(p.parent.tree)` is never greater than 1.
- The `getServerURL` function at `mgc/sdk/openapi/operation.go` has an issue with the `o.forEachServerVariable(...)` call. If no server variables are found in an OpenAPI schema, the URL is incorrectly built since `url = server.URL` is never reached.

## How to test it

Here's a basic schema that can be used for testing:
```
openapi: 3.0.2
info:
    title: SWAPI - Star Wars API
    version: 1.0.0
paths:
    /people/{people_id}:
        get:
            tags:
            - people
            summary: Get a specific people resource
            description: Get a people resource
            operationId: get_people
            parameters:
            -   description: people_id
                required: true
                schema:
                    title: People ID
                    type: integer
                name: people_id
                in: path
            responses:
                '200':
                    description: A specific people resource
                    content:
                        application/json:
                            schema:
                                $ref: '#/components/schemas/PeopleResponse'
components:
    schemas:
        PeopleResponse:
            title: PeopleResponse
            type: object
            properties:
                name:
                    title: Name
                    type: string
                    description: The name of this person.
tags:
-   name: people
    description: people
servers:
-   url: https://swapi.dev/api
```

Copy its contents to a new file, `mgc/cli/openapis/swapi.openapi.yaml`, and include it in `mgc/cli/openapis/index.yaml`:
```
-   description: APIs referentes à SWAPI
    name: swapi
    path: swapi.openapi.yaml
    version: 1.0.0
```

You should be able to run the `get` command now with no issues:
```
$ go run main.go swapi people get --people-id 1
{
 "birth_year": "19BBY",
 "created": "2014-12-09T13:50:51.644000Z",
 "edited": "2014-12-20T21:17:56.891000Z",
 "eye_color": "blue",
 "films": [
  "https://swapi.dev/api/films/1/",
  "https://swapi.dev/api/films/2/",
  "https://swapi.dev/api/films/3/",
  "https://swapi.dev/api/films/6/"
 ],
 "gender": "male",
 "hair_color": "blond",
 "height": "172",
 "homeworld": "https://swapi.dev/api/planets/1/",
 "mass": "77",
 "name": "Luke Skywalker",
 "skin_color": "fair",
 "species": [],
 "starships": [
  "https://swapi.dev/api/starships/12/",
  "https://swapi.dev/api/starships/22/"
 ],
 "url": "https://swapi.dev/api/people/1/",
 "vehicles": [
  "https://swapi.dev/api/vehicles/14/",
  "https://swapi.dev/api/vehicles/30/"
 ]
}
```
