### PR TITLE
fix(core): add logger to static execute

### DIFF
--- a/mgc/core/config/config.go
+++ b/mgc/core/config/config.go
@@ -3,12 +3,10 @@ package config
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path"
 
 	"magalu.cloud/core"
-	"magalu.cloud/core/logger"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
@@ -47,8 +45,7 @@ func FromContext(ctx context.Context) *Config {
 func New() *Config {
 	dirname, err := core.BuildMGCPath()
 	if err != nil {
-		// TODO: when it's done, use logger instead
-		log.Println(err)
+		logger().Warnln(err)
 	}
 
 	c := &Config{}
@@ -73,7 +70,7 @@ func (c *Config) init(dirname string, fs afero.Fs) {
 }
 
 func (c *Config) BuiltInConfigs() (map[string]*core.Schema, error) {
-	loggerConfigSchema, err := logger.ConfigSchema()
+	loggerConfigSchema, err := loggerSchema()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get logger config schema: %w", err)
 	}

--- a/mgc/core/config/logger.go
+++ b/mgc/core/config/logger.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/invopop/jsonschema"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"magalu.cloud/core"
+	coreLogger "magalu.cloud/core/logger"
+)
+
+type pkgSymbol struct{}
+
+var pkgLogger *zap.SugaredLogger
+
+func logger() *zap.SugaredLogger {
+	if pkgLogger == nil {
+		pkgLogger = coreLogger.New[pkgSymbol]()
+	}
+	return pkgLogger
+}
+
+func loggerSchema() (*core.Schema, error) {
+	reflector := jsonschema.Reflector{Mapper: zapMapper}
+	s, err := core.ToCoreSchema(reflector.Reflect(zap.Config{}))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create JSON Schema for type '%T': %w", zap.Config{}, err)
+	}
+
+	removeRequired(s)
+
+	s.Description = "Logger configuration. For more information see https://pkg.go.dev/go.uber.org/zap#Config"
+
+	return s, nil
+}
+
+func removeRequired(s *core.Schema) {
+	if len(s.Required) != 0 {
+		s.Required = []string{}
+	}
+	for _, ref := range s.Properties {
+		if ref.Value != nil {
+			removeRequired(((*core.Schema)(ref.Value)))
+		}
+	}
+}
+
+func levelEncoder(zapcore.Level, zapcore.PrimitiveArrayEncoder)        {}
+func timeEncoder(time.Time, zapcore.PrimitiveArrayEncoder)             {}
+func durationEncoder(time.Duration, zapcore.PrimitiveArrayEncoder)     {}
+func callerEncoder(zapcore.EntryCaller, zapcore.PrimitiveArrayEncoder) {}
+func nameEncoder(string, zapcore.PrimitiveArrayEncoder)                {}
+
+// The zapMapper function is necessary because some zapcore.EncoderConfig
+// fields are functions, and it's not possiple to reflect these fields
+// to a jsonschema.Schema. So we have to tell jsonschema how to handle them
+
+func zapMapper(t reflect.Type) *jsonschema.Schema {
+	switch t {
+	case reflect.TypeOf(zap.AtomicLevel{}):
+		return &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{
+				"debug",
+				"info",
+				"warn",
+				"error",
+				"panic",
+				"dpanic",
+				"fatal",
+			},
+		}
+	case reflect.TypeOf(zapcore.LevelEncoder(levelEncoder)):
+		return &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{
+				"capital",
+				"color",
+				"capitalColor",
+				"default",
+			}}
+	case reflect.TypeOf(zapcore.TimeEncoder(timeEncoder)):
+		return &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{
+				"rfc3339nano", "RFC3339Nano",
+				"rfc3339", "RFC3339",
+				"iso8601", "ISO8601",
+				"millis",
+				"nanos",
+				"default",
+			}}
+	case reflect.TypeOf(zapcore.DurationEncoder(durationEncoder)):
+		return &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{
+				"string",
+				"nanos",
+				"ms",
+				"default",
+			},
+		}
+	case reflect.TypeOf(zapcore.CallerEncoder(callerEncoder)):
+		return &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{
+				"string",
+				"default",
+			},
+		}
+	case reflect.TypeOf(zapcore.NameEncoder(nameEncoder)):
+		return &jsonschema.Schema{
+			Type: "string",
+			Enum: []any{
+				"full",
+				"default",
+			},
+		}
+	default:
+		return nil
+	}
+}

--- a/mgc/core/logger/logger.go
+++ b/mgc/core/logger/logger.go
@@ -1,15 +1,9 @@
 package logger
 
 import (
-	"fmt"
 	"reflect"
-	"time"
 
-	"magalu.cloud/core"
-
-	"github.com/invopop/jsonschema"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var rootLogger *zap.SugaredLogger
@@ -27,105 +21,4 @@ func Root() *zap.SugaredLogger {
 
 func SetRoot(logger *zap.SugaredLogger) {
 	rootLogger = logger
-}
-
-func removeRequired(s *core.Schema) {
-	if len(s.Required) != 0 {
-		s.Required = []string{}
-	}
-	for _, ref := range s.Properties {
-		if ref.Value != nil {
-			removeRequired(((*core.Schema)(ref.Value)))
-		}
-	}
-}
-
-func ConfigSchema() (*core.Schema, error) {
-	reflector := jsonschema.Reflector{Mapper: zapMapper}
-	s, err := core.ToCoreSchema(reflector.Reflect(zap.Config{}))
-	if err != nil {
-		return nil, fmt.Errorf("unable to create JSON Schema for type '%T': %w", zap.Config{}, err)
-	}
-
-	removeRequired(s)
-
-	s.Description = "Logger configuration. For more information see https://pkg.go.dev/go.uber.org/zap#Config"
-
-	return s, nil
-}
-
-func levelEncoder(zapcore.Level, zapcore.PrimitiveArrayEncoder)        {}
-func timeEncoder(time.Time, zapcore.PrimitiveArrayEncoder)             {}
-func durationEncoder(time.Duration, zapcore.PrimitiveArrayEncoder)     {}
-func callerEncoder(zapcore.EntryCaller, zapcore.PrimitiveArrayEncoder) {}
-func nameEncoder(string, zapcore.PrimitiveArrayEncoder)                {}
-
-// The zapMapper function is necessary because some zapcore.EncoderConfig
-// fields are functions, and it's not possiple to reflect these fields
-// to a jsonschema.Schema. So we have to tell jsonschema how to handle them
-
-func zapMapper(t reflect.Type) *jsonschema.Schema {
-	switch t {
-	case reflect.TypeOf(zap.AtomicLevel{}):
-		return &jsonschema.Schema{
-			Type: "string",
-			Enum: []any{
-				"debug",
-				"info",
-				"warn",
-				"error",
-				"panic",
-				"dpanic",
-				"fatal",
-			},
-		}
-	case reflect.TypeOf(zapcore.LevelEncoder(levelEncoder)):
-		return &jsonschema.Schema{
-			Type: "string",
-			Enum: []any{
-				"capital",
-				"color",
-				"capitalColor",
-				"default",
-			}}
-	case reflect.TypeOf(zapcore.TimeEncoder(timeEncoder)):
-		return &jsonschema.Schema{
-			Type: "string",
-			Enum: []any{
-				"rfc3339nano", "RFC3339Nano",
-				"rfc3339", "RFC3339",
-				"iso8601", "ISO8601",
-				"millis",
-				"nanos",
-				"default",
-			}}
-	case reflect.TypeOf(zapcore.DurationEncoder(durationEncoder)):
-		return &jsonschema.Schema{
-			Type: "string",
-			Enum: []any{
-				"string",
-				"nanos",
-				"ms",
-				"default",
-			},
-		}
-	case reflect.TypeOf(zapcore.CallerEncoder(callerEncoder)):
-		return &jsonschema.Schema{
-			Type: "string",
-			Enum: []any{
-				"string",
-				"default",
-			},
-		}
-	case reflect.TypeOf(zapcore.NameEncoder(nameEncoder)):
-		return &jsonschema.Schema{
-			Type: "string",
-			Enum: []any{
-				"full",
-				"default",
-			},
-		}
-	default:
-		return nil
-	}
 }

--- a/mgc/core/static_execute.go
+++ b/mgc/core/static_execute.go
@@ -3,11 +3,12 @@ package core
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/invopop/jsonschema"
+	"go.uber.org/zap"
+	coreLogger "magalu.cloud/core/logger"
 )
 
 type StaticExecute struct {
@@ -19,6 +20,15 @@ type StaticExecute struct {
 	result      *Schema
 	links       map[string]Linker
 	execute     func(ctx context.Context, parameters Parameters, configs Configs) (value Value, err error)
+}
+
+var corePkgLogger *zap.SugaredLogger
+
+func logger() *zap.SugaredLogger {
+	if corePkgLogger == nil {
+		corePkgLogger = coreLogger.New[StaticExecute]()
+	}
+	return corePkgLogger
 }
 
 // Raw Parameter and Config JSON Schemas
@@ -83,15 +93,15 @@ func NewStaticExecuteWithLinks[ParamsT any, ConfigsT any, ResultT any](
 ) *StaticExecute {
 	ps, err := schemaFromType[ParamsT]()
 	if err != nil {
-		log.Fatal(err)
+		logger().Fatal(err)
 	}
 	cs, err := schemaFromType[ConfigsT]()
 	if err != nil {
-		log.Fatal(err)
+		logger().Fatal(err)
 	}
 	rs, err := schemaFromType[ResultT]()
 	if err != nil {
-		log.Fatal(err)
+		logger().Fatal(err)
 	}
 
 	return NewRawStaticExecute(


### PR DESCRIPTION
In order to do that, needed to extract from core/logger/logger.go the logic that depended on `core.` components. This was needed because otherwise importing a logger would cause an import cycle.

- Closes #291 