### PR TITLE
fix: vm openapi spec invalid method

### DIFF
--- a/mgc/cli/openapis/virtual-machine.openapi.yaml
+++ b/mgc/cli/openapis/virtual-machine.openapi.yaml
@@ -260,8 +260,6 @@ paths:
             -   OAuth2:
                 - virtual-machine.write
             x-cli-description: Create a Virtual Machine instance
-        delete:
-            x-cli-description: Delete a Virtual Machine instance
     /v0/instances/{id}:
         get:
             tags:


### PR DESCRIPTION
Remove leftover method information