### PR TITLE
chore(build): remove libc dep from build binaries

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -20,7 +20,8 @@ mkdir -p "$BUILDDIR"
 for D in `go tool dist list | grep "$DESIRED_DIST_REGEXP"`; do
     OS=`echo "$D" | cut -d/ -f1`
     ARCH=`echo "$D" | cut -d/ -f2`
-    GOOS="$OS" GOARCH="$ARCH" go build -tags "$TAGS" -ldflags "$LDFLAGS" -o "$BUILDDIR/$NAME-$OS-$ARCH-$VERSION" "$ENTRYPOINT"
+    EXT=`if [ "$OS" = "windows" ]; then echo ".exe"; fi`
+    GOOS="$OS" GOARCH="$ARCH" go build -tags "$TAGS" -ldflags "$LDFLAGS" -o "$BUILDDIR/$NAME-$OS-$ARCH-$VERSION$EXT" "$ENTRYPOINT"
 done
 
 cp mgc/cli/RUNNING.md "$BUILDDIR/README.md"


### PR DESCRIPTION
## Description

Set CGO_ENABLED flag to zero to mitigate problems when using the binaries in environments with different versions of libc

