### PR TITLE
feat(s3): list subdirectory and fetch if downloaded path is from an object

### DIFF
--- a/mgc/sdk/static/object_storage/objects/upload.go
+++ b/mgc/sdk/static/object_storage/objects/upload.go
@@ -42,7 +42,7 @@ func formatURI(uri string) string {
 func upload(ctx context.Context, params uploadParams, cfg s3.Config) (*uploadTemplateResult, error) {
 	dst, _ := strings.CutPrefix(params.Destination, s3.URIPrefix)
 	_, fileName := path.Split(params.Source)
-	if !isFilePath(dst) {
+	if isDirPath(dst) {
 		// If it isn't a file path, don't rename, just append source with bucket URI
 		dst = path.Join(dst, fileName)
 	}


### PR DESCRIPTION
## Description

* Make it possible to list a subdirectory content on the `objects list` command
* Check if the downloaded path is from an object or a directory by sending a `HEAD` request for the resource

Also, created an error if the user tries to download a folder but specifies a file in the destination.

## Related Issues

- Closes #279 

## How to Test

* List subdirectories:

```shell
$ go run main.go --access-key-id=$ACCESS_KEY --secret-key=$SECRET_KEY object-storage objects list --dst "test/subdir1/subdir2/" -o yaml
Contents:
    - Key: subdir1/subdir2/a.txt
      LastModified: "2023-10-11T15:51:37.650Z"
      Size: 7
    - Key: subdir1/subdir2/test.txt
      LastModified: "2023-10-11T14:22:29.039Z"
      Size: 7
Name: test
SubDirectories:
    - Path: subdir1/subdir2/subdir3/
```

* Download an object specifying a file as the destination, which should return an error:

```shell
$ go run main.go --access-key-id=$ACCESS_KEY --secret-key=$SECRET_KEY object-storage objects download --src "s3://test/subdir1/" --dst ./out2.txt
Usage:
  mgc object-storage objects download [flags]

Error: bucket resource s3://test/subdir1/ is a directory but given local path is a file ./out2.txt
exit status 1
```

* Download a single file:

```shell
$ go run main.go --access-key-id=$ACCESS_KEY --secret-key=$SECRET_KEY object-storage objects download --src "s3://test/subdir1/test.txt" --dst a.out
Downloaded from s3://test/subdir1/test.txt to a.out
$ cat a.out
A test
```

* Download multiple files:

```shell
$ go run main.go --access-key-id=$ACCESS_KEY --secret-key=$SECRET_KEY object-storage objects download --src "s3://test/subdir1" --dst out2
Downloaded from s3://test/subdir1 to out2
$ find out2
out2
out2/subdir1
out2/subdir1/test.txt
```