### PR TITLE
fix: Duplicated operation names in CLI for block-storage snapshots

### DIFF
--- a/mgc/cli/openapis/block-storage.openapi.yaml
+++ b/mgc/cli/openapis/block-storage.openapi.yaml
@@ -214,6 +214,7 @@ paths:
             security:
             -   OAuth2:
                 - block-storage.write
+            x-cli-name: restore
         delete:
             tags:
             - snapshots

--- a/openapi-customizations/block-storage.openapi.yaml
+++ b/openapi-customizations/block-storage.openapi.yaml
@@ -118,6 +118,9 @@ paths:
                             description: Delete snapshot
                             parameters:
                                 snapshot_id: $response.body#/id
+    /v0/snapshots/{snapshot_id}:
+        post:
+            x-cli-name: restore
 
 
 tags:


### PR DESCRIPTION
## Description

This PR fixes a duplicated operation name issue with `create` for `block-storage snapshots`.

## How to test it

At `mgc/cli/`:
```
$ go run main.go block-storage snapshots
snapshots

Usage:
  mgc block-storage snapshots [flags]
  mgc block-storage snapshots [command]

Available Commands:
  create      Restore a snapshot
  delete      Delete a snapshot from the provided tenant_id
  list        List snapshots
  restore     Create snapshot
...
```