### PR TITLE
feat: Configure `User-Agent` Header

### DIFF
--- a/mgc/sdk/sdk.go
+++ b/mgc/sdk/sdk.go
@@ -151,6 +151,8 @@ func newHttpTransport() http.RoundTripper {
 		DisableCompression: true,
 	}
 	transport = coreHttp.NewDefaultClientLogger(transport)
+	userAgent := "MgcCLI/" + Version
+	transport = newDefaultSdkTransport(transport, userAgent)
 	return transport
 }
 

--- a/mgc/sdk/sdk_transport.go
+++ b/mgc/sdk/sdk_transport.go
@@ -1,0 +1,29 @@
+package sdk
+
+import "net/http"
+
+var _ http.RoundTripper = (*DefaultSdkTransport)(nil)
+
+type DefaultSdkTransport struct {
+	Transport http.RoundTripper
+	UserAgent string
+}
+
+func newDefaultSdkTransport(transport http.RoundTripper, userAgent string) *DefaultSdkTransport {
+	return &DefaultSdkTransport{
+		Transport: transport,
+		UserAgent: userAgent,
+	}
+}
+
+func (t *DefaultSdkTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", t.UserAgent)
+
+	transport := t.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	resp, err := transport.RoundTrip(req)
+
+	return resp, err
+}

--- a/mgc/sdk/version_release.go
+++ b/mgc/sdk/version_release.go
@@ -1,0 +1,3 @@
+package sdk
+
+const Version = "v0.7.1"


### PR DESCRIPTION
## Description

This PR adds the `User-Agent` header to HTTP requests by setting it as `MgcCLI/<latest_tag>` in the SDK.

## Related Issues

- #395

## Progress

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run any command with the log flag set as follows: `-l 'debug+:magalu.cloud/core/http'`.

You should see `"User-Agent":"MgcCLI/v0.7.1"` in the output, as in the end of this example:
```
DEBUG	magalu.cloud/core/http	request	{"method": "POST", "url": "https://id.magalu.com/oauth/token", "protocol": "HTTP/1.1", "headers": {"Content-Type":"application/x-www-form-urlencoded","User-Agent":"MgcCLI/v0.7.1"}}
```