### PR TITLE
feat: add warning for CLI log flag usage

### DIFF
--- a/mgc/cli/RUNNING.md
+++ b/mgc/cli/RUNNING.md
@@ -2,6 +2,18 @@
 
 First download or build the `mgc` cli.
 
+## Flag usage guidelines
+
+Running `./mgc` will provide a list of available `--cli.` flags, such as `--cli.log`,
+`--cli.output` and more. These are global flags that can be used to specify certain
+behaviors for each command, such as producing logs in the case of `--cli.log`. Further
+instructions will be provided beside each flag. Due to how groups and executors are
+handled, **for any given command, these flags should always be placed before any flags
+that are specific to the command itself in order to ensure proper functionality**.
+For example:
+`./mgc virtual-machine instances delete --cli.log "*:*" --id ...`. Notice how
+`--cli.log` is going before `--id`.
+
 ## Input handling with prefixes
 
 When providing flags to a command, we can use one of the following prefixes to get the
@@ -104,6 +116,12 @@ the `file:line` of the caller:
 Then one can run commands using `--cli.log` or `-l` followed by a [pattern](https://github.com/moul/zapfilter), which takes one of the forms below:
 - `levels:namespaces`
 - `namespaces`
+
+> **NOTE:**
+> Always add the log flag before any of the command's flags, for example:
+> `./mgc virtual-machine instances delete --cli.log "*:*" --id ...`. Notice
+> how  `--cli.log` is going before `--id`. For more information, see the
+> [flag usage guidelines](#flag-usage-guidelines).
 
 Where `levels` is a comma-separated list of level names or `*` to show all.
 Note that level names are **exact**, if you want to use that level or greater,


### PR DESCRIPTION
## Description

This PR adds a warning to always place the log flag before any command flags when running a given command. While at first this was considered to be related to a bug, it is actually a kind of handling that Cobra currently does not provide by itself.

For investigation purposes, see [getLogFilterFlag() at log_filter.go](https://github.com/profusion/magalu/blob/main/mgc/cli/cmd/log_filter.go#L20). If you attempt to send a command with the `--cli.log` flag at the very end of it, you can see through print statements that the flag does end up in `os.Args[1:]`, however, the return statement will still return `warn+:*`.

## Related Issues

- #423

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)
