### PR TITLE
Fix bucketURI parsing with trailing slash

### DIFF
--- a/mgc/sdk/static/object_storage/objects/list.go
+++ b/mgc/sdk/static/object_storage/objects/list.go
@@ -48,6 +48,9 @@ func newList() core.Executor {
 }
 
 func parseURL(cfg s3.Config, bucketURI string) (*url.URL, error) {
+	// Bucket URI cannot end in '/' as this makes it search for a
+	// non existing directory
+	bucketURI = strings.TrimSuffix(bucketURI, "/")
 	dirs := strings.Split(bucketURI, "/")
 	path, err := url.JoinPath(s3.BuildHost(cfg), dirs[0])
 	if err != nil {


### PR DESCRIPTION
## Description
Trailing slashes create weird behaviour in the function. This fixes this behaviour.

Example of weird behaviour causing URI: `s3://my-bucket/`

## How to test
URIs like `s3://my-bucket/` should now work with or without the trailing slash