### PR TITLE
fix(sdk): make version handling more robust

### DIFF
--- a/mgc/sdk/version.go
+++ b/mgc/sdk/version.go
@@ -1,0 +1,13 @@
+package sdk
+
+import (
+	_ "embed"
+	"strings"
+)
+
+//go:embed version.txt
+var rawVersion string
+
+var version string = func() string {
+	return strings.Trim(rawVersion, " \t\n\r")
+}()

--- a/mgc/sdk/version_development.go
+++ b/mgc/sdk/version_development.go
@@ -6,12 +6,7 @@ package sdk
 import (
 	"fmt"
 	"runtime/debug"
-
-	_ "embed"
 )
-
-//go:embed version.txt
-var baseVersion string
 
 var Version = func() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
@@ -30,9 +25,9 @@ var Version = func() string {
 		}
 
 		if vcs != "" {
-			return fmt.Sprintf("%s-%s-%s%s", baseVersion, vcs, rev, status)
+			return fmt.Sprintf("%s-%s-%s%s", version, vcs, rev, status)
 		}
 	}
 
-	return baseVersion + " (vcs-unknown, please 'go build -buildvcs=true')"
+	return version + " (vcs-unknown, please 'go build -buildvcs=true')"
 }()

--- a/mgc/sdk/version_release.go
+++ b/mgc/sdk/version_release.go
@@ -2,7 +2,4 @@
 
 package sdk
 
-import _ "embed"
-
-//go:embed version.txt
-var Version string
+var Version string = version


### PR DESCRIPTION
we can't have \n at the end of the file, so trim spaces around it

