### PR TITLE
feat(object-storage): allow retry of big file upload request

### DIFF
--- a/mgc/sdk/static/object_storage/s3/bigfile_uploader.go
+++ b/mgc/sdk/static/object_storage/s3/bigfile_uploader.go
@@ -163,6 +163,11 @@ func (u *bigFileUploader) createPartSenderProcessor(cancel context.CancelCauseFu
 			return part, pipeline.ProcessAbort
 		}
 
+		// This is used while retrying requests
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(io.NewSectionReader(chunk.Reader, 0, CHUNK_SIZE)), nil
+		}
+
 		bigfileUploaderLogger().Debugw("Sending part", "part", partNumber, "total", totalParts)
 		_, res, err := SendRequest[any](ctx, req)
 		if err != nil {


### PR DESCRIPTION
## Description

This was unable to happen before because the body for this request is an `io.SectionReader`, which is not directly clonable. To allow this, define a `GetBody` function on the request to create a new SectionReader based on the original one.

## Related Issues

- Closes #415 

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it
See #359
