### PR TITLE
refactor(object-storage): rename s3 module to swift

### DIFF
--- a/mgc/sdk/static/object_storage/buckets/create.go
+++ b/mgc/sdk/static/object_storage/buckets/create.go
@@ -7,7 +7,7 @@ import (
 
 	"magalu.cloud/core"
 	"magalu.cloud/core/utils"
-	"magalu.cloud/sdk/static/object_storage/s3"
+	"magalu.cloud/sdk/static/object_storage/common"
 )
 
 type createParams struct {
@@ -19,7 +19,7 @@ type createParams struct {
 var getCreate = utils.NewLazyLoader[core.Executor](newCreate)
 
 func newCreate() core.Executor {
-	executor := core.NewReflectedSimpleExecutor[createParams, s3.Config, core.Value](
+	executor := core.NewReflectedSimpleExecutor[createParams, common.Config, core.Value](
 		core.ExecutorSpec{
 			DescriptorSpec: core.DescriptorSpec{
 				Name:        "create",
@@ -38,8 +38,8 @@ func newCreate() core.Executor {
 	})
 }
 
-func newCreateRequest(ctx context.Context, cfg s3.Config, bucket string) (*http.Request, error) {
-	host := s3.BuildHost(cfg)
+func newCreateRequest(ctx context.Context, cfg common.Config, bucket string) (*http.Request, error) {
+	host := common.BuildHost(cfg)
 	url, err := url.JoinPath(host, bucket)
 	if err != nil {
 		return nil, err
@@ -47,13 +47,13 @@ func newCreateRequest(ctx context.Context, cfg s3.Config, bucket string) (*http.
 	return http.NewRequestWithContext(ctx, http.MethodPut, url, nil)
 }
 
-func create(ctx context.Context, params createParams, cfg s3.Config) (core.Value, error) {
+func create(ctx context.Context, params createParams, cfg common.Config) (core.Value, error) {
 	req, err := newCreateRequest(ctx, cfg, params.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	_, _, err = s3.SendRequest[core.Value](ctx, req)
+	_, _, err = common.SendRequest[core.Value](ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/mgc/sdk/static/object_storage/buckets/list.go
+++ b/mgc/sdk/static/object_storage/buckets/list.go
@@ -6,7 +6,7 @@ import (
 
 	"magalu.cloud/core"
 	"magalu.cloud/core/utils"
-	"magalu.cloud/sdk/static/object_storage/s3"
+	"magalu.cloud/sdk/static/object_storage/common"
 )
 
 type BucketResponse struct {
@@ -27,8 +27,8 @@ type ListResponse struct {
 
 var getList = utils.NewLazyLoader[core.Executor](newList)
 
-func newListRequest(ctx context.Context, cfg s3.Config) (*http.Request, error) {
-	return http.NewRequestWithContext(ctx, http.MethodGet, s3.BuildHost(cfg), nil)
+func newListRequest(ctx context.Context, cfg common.Config) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, http.MethodGet, common.BuildHost(cfg), nil)
 }
 
 func newList() core.Executor {
@@ -41,12 +41,12 @@ func newList() core.Executor {
 	)
 }
 
-func list(ctx context.Context, _ struct{}, cfg s3.Config) (result ListResponse, err error) {
+func list(ctx context.Context, _ struct{}, cfg common.Config) (result ListResponse, err error) {
 	req, err := newListRequest(ctx, cfg)
 	if err != nil {
 		return
 	}
 
-	result, _, err = s3.SendRequest[ListResponse](ctx, req)
+	result, _, err = common.SendRequest[ListResponse](ctx, req)
 	return
 }

--- a/mgc/sdk/static/object_storage/common/bigfile_uploader.go
+++ b/mgc/sdk/static/object_storage/common/bigfile_uploader.go
@@ -1,4 +1,4 @@
-package s3
+package common
 
 import (
 	"bytes"

--- a/mgc/sdk/static/object_storage/common/config.go
+++ b/mgc/sdk/static/object_storage/common/config.go
@@ -1,9 +1,9 @@
-package s3
+package common
 
 import "magalu.cloud/core/config"
 
 type Config struct {
-	Token   string `json:"token,omitempty" jsonschema:"description=Token for S3 Credentials"`
+	Token   string `json:"token,omitempty" jsonschema:"description=Token for object-storage Credentials"`
 	Workers int    `json:"workers,omitempty" jsonschema:"description=Number of routines that spawn to do parallel operations within object_storage,default=5,exlusiveMinimum=0"`
 	Region  string `json:"region,omitempty" jsonschema:"description=Region to reach the service,default=br-ne-1,enum=br-ne-1,enum=br-ne-2,enum=br-se-1"`
 	// See more about the 'squash' directive here: https://pkg.go.dev/github.com/mitchellh/mapstructure#hdr-Embedded_Structs_and_Squashing

--- a/mgc/sdk/static/object_storage/common/const.go
+++ b/mgc/sdk/static/object_storage/common/const.go
@@ -1,4 +1,4 @@
-package s3
+package common
 
 const (
 	authorizationHeaderKey = "Authorization"

--- a/mgc/sdk/static/object_storage/common/logger.go
+++ b/mgc/sdk/static/object_storage/common/logger.go
@@ -1,4 +1,4 @@
-package s3
+package common
 
 import mgcLoggerPkg "magalu.cloud/core/logger"
 

--- a/mgc/sdk/static/object_storage/common/session.go
+++ b/mgc/sdk/static/object_storage/common/session.go
@@ -1,4 +1,4 @@
-package s3
+package common
 
 import (
 	"context"

--- a/mgc/sdk/static/object_storage/common/sign.go
+++ b/mgc/sdk/static/object_storage/common/sign.go
@@ -1,4 +1,4 @@
-package s3
+package common
 
 import (
 	"bytes"

--- a/mgc/sdk/static/object_storage/common/smallfile_uploader.go
+++ b/mgc/sdk/static/object_storage/common/smallfile_uploader.go
@@ -1,4 +1,4 @@
-package s3
+package common
 
 import (
 	"context"

--- a/mgc/sdk/static/object_storage/common/uploader.go
+++ b/mgc/sdk/static/object_storage/common/uploader.go
@@ -1,4 +1,4 @@
-package s3
+package common
 
 import (
 	"context"
@@ -17,7 +17,7 @@ type uploader interface {
 	Upload(context.Context) error
 }
 
-func NewS3Uploader(cfg Config, src, dst string) (uploader, error) {
+func NewUploader(cfg Config, src, dst string) (uploader, error) {
 	reader, fileInfo, err := readContent(src)
 	if err != nil {
 		return nil, fmt.Errorf("error reading object: %w", err)

--- a/mgc/sdk/static/object_storage/objects/delete.go
+++ b/mgc/sdk/static/object_storage/objects/delete.go
@@ -8,7 +8,7 @@ import (
 
 	"magalu.cloud/core"
 	"magalu.cloud/core/utils"
-	"magalu.cloud/sdk/static/object_storage/s3"
+	"magalu.cloud/sdk/static/object_storage/common"
 )
 
 type DeleteObjectParams struct {
@@ -34,8 +34,8 @@ func newDelete() core.Executor {
 	)
 }
 
-func newDeleteRequest(ctx context.Context, cfg s3.Config, pathURIs ...string) (*http.Request, error) {
-	host := s3.BuildHost(cfg)
+func newDeleteRequest(ctx context.Context, cfg common.Config, pathURIs ...string) (*http.Request, error) {
+	host := common.BuildHost(cfg)
 	url, err := url.JoinPath(host, pathURIs...)
 	if err != nil {
 		return nil, err
@@ -43,13 +43,13 @@ func newDeleteRequest(ctx context.Context, cfg s3.Config, pathURIs ...string) (*
 	return http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 }
 
-func Delete(ctx context.Context, params DeleteObjectParams, cfg s3.Config) (result core.Value, err error) {
-	bucketURI, _ := strings.CutPrefix(params.Destination, s3.URIPrefix)
+func Delete(ctx context.Context, params DeleteObjectParams, cfg common.Config) (result core.Value, err error) {
+	bucketURI, _ := strings.CutPrefix(params.Destination, common.URIPrefix)
 	req, err := newDeleteRequest(ctx, cfg, bucketURI)
 	if err != nil {
 		return nil, err
 	}
 
-	result, _, err = s3.SendRequest[core.Value](ctx, req)
+	result, _, err = common.SendRequest[core.Value](ctx, req)
 	return
 }

--- a/mgc/sdk/static/object_storage/objects/list.go
+++ b/mgc/sdk/static/object_storage/objects/list.go
@@ -8,7 +8,7 @@ import (
 
 	"magalu.cloud/core"
 	"magalu.cloud/core/utils"
-	"magalu.cloud/sdk/static/object_storage/s3"
+	"magalu.cloud/sdk/static/object_storage/common"
 )
 
 type ListObjectsParams struct {
@@ -31,7 +31,7 @@ type ListObjectsResponse struct {
 	CommonPrefixes []*prefix        `xml:"CommonPrefixes" json:"SubDirectories"`
 }
 
-func newListRequest(ctx context.Context, cfg s3.Config, bucket string) (*http.Request, error) {
+func newListRequest(ctx context.Context, cfg common.Config, bucket string) (*http.Request, error) {
 	parsedUrl, err := parseURL(cfg, bucket)
 	if err != nil {
 		return nil, err
@@ -51,12 +51,12 @@ func newList() core.Executor {
 	)
 }
 
-func parseURL(cfg s3.Config, bucketURI string) (*url.URL, error) {
+func parseURL(cfg common.Config, bucketURI string) (*url.URL, error) {
 	// Bucket URI cannot end in '/' as this makes it search for a
 	// non existing directory
 	bucketURI = strings.TrimSuffix(bucketURI, "/")
 	dirs := strings.Split(bucketURI, "/")
-	path, err := url.JoinPath(s3.BuildHost(cfg), dirs[0])
+	path, err := url.JoinPath(common.BuildHost(cfg), dirs[0])
 	if err != nil {
 		return nil, err
 	}
@@ -81,13 +81,13 @@ func parseURL(cfg s3.Config, bucketURI string) (*url.URL, error) {
 	return u, nil
 }
 
-func List(ctx context.Context, params ListObjectsParams, cfg s3.Config) (result ListObjectsResponse, err error) {
-	bucket, _ := strings.CutPrefix(params.Destination, s3.URIPrefix)
+func List(ctx context.Context, params ListObjectsParams, cfg common.Config) (result ListObjectsResponse, err error) {
+	bucket, _ := strings.CutPrefix(params.Destination, common.URIPrefix)
 	req, err := newListRequest(ctx, cfg, bucket)
 	if err != nil {
 		return
 	}
 
-	result, _, err = s3.SendRequest[ListObjectsResponse](ctx, req)
+	result, _, err = common.SendRequest[ListObjectsResponse](ctx, req)
 	return
 }

--- a/mgc/sdk/static/object_storage/objects/upload.go
+++ b/mgc/sdk/static/object_storage/objects/upload.go
@@ -7,7 +7,7 @@ import (
 
 	"magalu.cloud/core"
 	"magalu.cloud/core/utils"
-	"magalu.cloud/sdk/static/object_storage/s3"
+	"magalu.cloud/sdk/static/object_storage/common"
 )
 
 type uploadParams struct {
@@ -37,21 +37,21 @@ func newUpload() core.Executor {
 }
 
 func formatURI(uri string) string {
-	if !strings.Contains(uri, s3.URIPrefix) {
-		return s3.URIPrefix + uri
+	if !strings.Contains(uri, common.URIPrefix) {
+		return common.URIPrefix + uri
 	}
 	return uri
 }
 
-func upload(ctx context.Context, params uploadParams, cfg s3.Config) (*uploadTemplateResult, error) {
-	dst, _ := strings.CutPrefix(params.Destination, s3.URIPrefix)
+func upload(ctx context.Context, params uploadParams, cfg common.Config) (*uploadTemplateResult, error) {
+	dst, _ := strings.CutPrefix(params.Destination, common.URIPrefix)
 	_, fileName := path.Split(params.Source)
 	if isDirPath(dst) {
 		// If it isn't a file path, don't rename, just append source with bucket URI
 		dst = path.Join(dst, fileName)
 	}
 
-	uploader, err := s3.NewS3Uploader(cfg, params.Source, dst)
+	uploader, err := common.NewUploader(cfg, params.Source, dst)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
MagaLu may use Swift as the underlying object-storage API, so we should make it clear in the naming that is not specific to s3.
