### PR TITLE
feat: add stats for typeless schemas

### DIFF
--- a/script-qa/spec_stats_dump.yml
+++ b/script-qa/spec_stats_dump.yml
@@ -72,6 +72,8 @@ block-storage.openapi:
     - usage:
         - post
         - delete
+  typeless-schemas:
+    - components.schemas.QosSpecs.specs
   unused-components:
     - '#/components/schemas/ValidationError'
 dbaas.openapi:
@@ -495,6 +497,65 @@ network.openapi:
     PATCH /v0/xaas/security_groups/{security_group_id}:
       parameters:
         - x-request-id
+  typeless-schemas:
+    - paths./v0/vpcs/{vpc_id}/ports.post.parameters.vpc_id.schema
+    - paths./v0/vpcs/{vpc_id}/ports.get.parameters.vpc_id.schema
+    - paths./v0/ports/{port_id}.get.parameters.port_id.schema
+    - paths./v0/ports/{port_id}.delete.parameters.port_id.schema
+    - paths./v0/ports/{port_id}/attach/{security_group_id}.post.parameters.port_id.schema
+    - paths./v0/ports/{port_id}/attach/{security_group_id}.post.parameters.security_group_id.schema
+    - paths./v0/ports/{port_id}/attach/{security_group_id}.post.responses.200.content.application/json.schema
+    - paths./v0/ports/{port_id}/detach/{security_group_id}.post.parameters.port_id.schema
+    - paths./v0/ports/{port_id}/detach/{security_group_id}.post.parameters.security_group_id.schema
+    - paths./v0/ports/{port_id}/detach/{security_group_id}.post.responses.200.content.application/json.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/ports.post.parameters.vpc_id.schema
+    - paths./v0/xaas/ports/{port_id}/attach/{security_group_id}.post.parameters.port_id.schema
+    - paths./v0/xaas/ports/{port_id}/attach/{security_group_id}.post.parameters.security_group_id.schema
+    - paths./v0/xaas/ports/{port_id}/attach/{security_group_id}.post.responses.200.content.application/json.schema
+    - paths./v0/xaas/ports/{port_id}/detach/{security_group_id}.post.parameters.port_id.schema
+    - paths./v0/xaas/ports/{port_id}/detach/{security_group_id}.post.parameters.security_group_id.schema
+    - paths./v0/xaas/ports/{port_id}/detach/{security_group_id}.post.responses.200.content.application/json.schema
+    - paths./v0/xaas/ports/{port_id}.get.parameters.port_id.schema
+    - paths./v0/xaas/ports/{port_id}.delete.parameters.port_id.schema
+    - paths./v0/vpcs/{vpc_id}/public_ips.post.parameters.vpc_id.schema
+    - paths./v0/vpcs/{vpc_id}/public_ips.get.parameters.vpc_id.schema
+    - paths./v0/public_ips/{public_ip_id}.get.parameters.public_ip_id.schema
+    - paths./v0/public_ips/{public_ip_id}.delete.parameters.public_ip_id.schema
+    - paths./v0/public_ips/{public_ip_id}/attach/{port_id}.post.parameters.public_ip_id.schema
+    - paths./v0/public_ips/{public_ip_id}/attach/{port_id}.post.parameters.port_id.schema
+    - paths./v0/public_ips/{public_ip_id}/attach/{port_id}.post.responses.200.content.application/json.schema
+    - paths./v0/public_ips/{public_ip_id}/detach/{port_id}.post.parameters.public_ip_id.schema
+    - paths./v0/public_ips/{public_ip_id}/detach/{port_id}.post.parameters.port_id.schema
+    - paths./v0/public_ips/{public_ip_id}/detach/{port_id}.post.responses.200.content.application/json.schema
+    - paths./v0/routers.get.responses.200.content.application/json.schema
+    - paths./v0/xaas/routers.get.responses.200.content.application/json.schema
+    - paths./v0/security_groups/{security_group_id}/rules.post.parameters.security_group_id.schema
+    - paths./v0/security_groups/{security_group_id}/rules.get.parameters.security_group_id.schema
+    - paths./v0/rules/{rule_id}.get.parameters.rule_id.schema
+    - paths./v0/rules/{rule_id}.delete.parameters.rule_id.schema
+    - paths./v0/xaas/security_groups/{security_group_id}/rules.post.parameters.security_group_id.schema
+    - paths./v0/xaas/security_groups/{security_group_id}/rules.get.parameters.security_group_id.schema
+    - paths./v0/xaas/rules/{rule_id}.get.parameters.rule_id.schema
+    - paths./v0/xaas/rules/{rule_id}.delete.parameters.rule_id.schema
+    - paths./v0/xaas/rules/{rule_id}.patch.parameters.rule_id.schema
+    - paths./v0/xaas/rules/{rule_id}.patch.parameters.x-request-id.schema
+    - paths./v0/vpcs/{vpc_id}/security_groups.get.parameters.vpc_id.schema
+    - paths./v0/security_groups/{security_group_id}.get.parameters.security_group_id.schema
+    - paths./v0/security_groups/{security_group_id}.delete.parameters.security_group_id.schema
+    - paths./v0/xaas/security_groups/{security_group_id}.get.parameters.security_group_id.schema
+    - paths./v0/xaas/security_groups/{security_group_id}.delete.parameters.security_group_id.schema
+    - paths./v0/xaas/security_groups/{security_group_id}.patch.parameters.security_group_id.schema
+    - paths./v0/xaas/security_groups/{security_group_id}.patch.parameters.x-request-id.schema
+    - paths./v0/vpcs/{vpc_id}.get.parameters.vpc_id.schema
+    - paths./v0/vpcs/{vpc_id}.delete.parameters.vpc_id.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/add_route.post.parameters.vpc_id.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/add_route.post.responses.201.content.application/json.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/delete_route.post.parameters.vpc_id.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/add_interface.post.parameters.vpc_id.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/add_interface.post.parameters.openapi_extra.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/delete_interface/{interface_id}.delete.parameters.vpc_id.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/delete_interface/{interface_id}.delete.parameters.interface_id.schema
+    - paths./v0/xaas/vpcs/{vpc_id}/interfaces.get.parameters.vpc_id.schema
   unused-components:
     - '#/components/schemas/ValidationError'
 virtual-machine.openapi:

--- a/scripts/spec_stats.py
+++ b/scripts/spec_stats.py
@@ -1014,6 +1014,7 @@ def fill_components_usage(o: OAPI) -> None:
 
 
 def get_oapi_stats(o: OAPI) -> OAPIStats:
+    oapi_walker = OAPIWalk(o)
     result: OAPIStats = {}
     resources: Dict[str, OAPIResource] = {}
     tagless_ops = fill_resources(o, resources)
@@ -1037,8 +1038,13 @@ def get_oapi_stats(o: OAPI) -> OAPIStats:
                     result[UNUSED_COMPONENTS] = []
                 result[UNUSED_COMPONENTS].append(name)
 
-    # TODO: Add stats for other fields
+    if filterer.should_include(TYPELESS_SCHEMAS):
+        schema_handler = SchemaHandler(result)
+        oapi_walker.add_handler(schema_handler.typeless_handler)
 
+    oapi_walker.dfs()
+
+    # TODO: Add stats for other fields
     return result
 
 


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

`scripts/spec_stats.py` now show schemas that do not have the `type` field

## Related Issues

- Closes #448 

## How to test it
- run `python3 ./scripts/spec_stats.py ./mgc/cli/openapis -o spec_stats_dump.yml`
- the result file `spec_stats_dump.ym` should sections for typeless schemas (if there is any)



