### PR TITLE
fix: use provided executable's name instead of "mgc"

### DIFF
--- a/mgc/cli/cmd/root.go
+++ b/mgc/cli/cmd/root.go
@@ -671,7 +671,7 @@ func Execute() (err error) {
 	sdk := &mgcSdk.Sdk{}
 
 	rootCmd := &cobra.Command{
-		Use:     "mgc",
+		Use:     os.Args[0],
 		Version: mgcSdk.Version,
 		Short:   "CLI tool for OpenAPI integration",
 		Long: `This CLI is a dynamic processor of OpenAPI files that


### PR DESCRIPTION
## Description

Fixing a bug where the CLI would always use "mgc" instead of the provided executable's name.

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

```
$ ./mgc-linux-amd64-v0.8.0 
This CLI is a dynamic processor of OpenAPI files that
can generate a command line on-demand for Rest manipulation

Usage:
  ./mgc-linux-amd64-v0.8.0 [flags]
...
```
