### PR TITLE
fix: get filename for CLI executable name display

### DIFF
--- a/mgc/cli/cmd/root.go
+++ b/mgc/cli/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"magalu.cloud/cli/ui"
@@ -642,9 +643,10 @@ func getLogFilterConfig(sdk *mgcSdk.Sdk) string {
 
 func Execute() (err error) {
 	sdk := &mgcSdk.Sdk{}
+	executableName := filepath.Base(os.Args[0])
 
 	rootCmd := &cobra.Command{
-		Use:     os.Args[0],
+		Use:     executableName,
 		Version: mgcSdk.Version,
 		Short:   "CLI tool for OpenAPI integration",
 		Long: `This CLI is a dynamic processor of OpenAPI files that


### PR DESCRIPTION
## Description

Running `go run main.go` would previously output:

```
$ go run main.go 
This CLI is a dynamic processor of OpenAPI files that
can generate a command line on-demand for Rest manipulation

Usage:
  /tmp/go-build3965603897/b001/exe/main [flags]
  /tmp/go-build3965603897/b001/exe/main [command]
  ```
  
  Now we should get:
  
  ```
  $ go run main.go 
This CLI is a dynamic processor of OpenAPI files that
can generate a command line on-demand for Rest manipulation

Usage:
  main [flags]
  main [command]
```

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

```
$ go run main.go 
This CLI is a dynamic processor of OpenAPI files that
can generate a command line on-demand for Rest manipulation

Usage:
main [flags]
main [command]
```