### PR TITLE
fix: propagate OpenAPI version info from modules to lower layers

### DIFF
--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -68,6 +68,7 @@ type operation struct {
 func newOperation(
 	name string,
 	desc *operationDesc,
+	version string,
 	method string,
 	extensionPrefix *string,
 	servers openapi3.Servers,
@@ -80,6 +81,7 @@ func newOperation(
 		SimpleDescriptor: core.SimpleDescriptor{Spec: core.DescriptorSpec{
 			Name:        name,
 			Description: getDescriptionExtension(extensionPrefix, desc.op.Extensions, desc.op.Description),
+			Version:     version,
 		}},
 		key:             desc.key,
 		method:          method,

--- a/mgc/sdk/openapi/resource.go
+++ b/mgc/sdk/openapi/resource.go
@@ -215,10 +215,12 @@ func newResource(
 	refResolver *core.BoundRefPathResolver,
 ) *core.SimpleGrouper[core.Executor] {
 	logger = logger.Named(tag.Name)
+	version := doc.Info.Version
 	return core.NewSimpleGrouper[core.Executor](
 		core.DescriptorSpec{
 			Name:        getNameExtension(extensionPrefix, tag.Extensions, tag.Name),
 			Description: getDescriptionExtension(extensionPrefix, tag.Extensions, tag.Description),
+			Version:     version,
 		},
 		func() (operations []core.Executor, err error) {
 			operations = []core.Executor{}
@@ -245,6 +247,7 @@ func newResource(
 				var operation core.Executor = newOperation(
 					opName,
 					desc,
+					version,
 					method,
 					extensionPrefix,
 					servers,


### PR DESCRIPTION
## Description

Resources and operations would have no account of their corresponding module's version. Through this PR we now we pass that information to those layers.

## Related Issues

- Related PR: #468 

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Example:
```
$ go run main.go virtual-machine -v
virtual-machine version 1.60.0
$ go run main.go virtual-machine images -v
images version 1.60.0
$ go run main.go virtual-machine images list -v
list version 1.60.0
```
