### PR TITLE
feat(cli): add '-f' shorthand to '--cli.bypass-confirmation' flag

### DIFF
--- a/mgc/cli/cmd/bypass_confirmation.go
+++ b/mgc/cli/cmd/bypass_confirmation.go
@@ -5,8 +5,9 @@ import "github.com/spf13/cobra"
 const bypassConfirmationFlag = "cli.bypass-confirmation"
 
 func addBypassConfirmationFlag(cmd *cobra.Command) {
-	cmd.Root().PersistentFlags().Bool(
+	cmd.Root().PersistentFlags().BoolP(
 		bypassConfirmationFlag,
+		"f",
 		false,
 		"Bypasses confirmation step for commands that ask a confirmation from the user",
 	)


### PR DESCRIPTION
closes #476 