### PR TITLE
fix(config): avoid yaml.Unmarshal changing type of 'any' address

### DIFF
--- a/mgc/core/config/config.go
+++ b/mgc/core/config/config.go
@@ -124,19 +124,20 @@ func stringUnmarshalHook(f reflect.Value, t reflect.Value) (interface{}, error) 
 		derefKind = dereferenced.Kind()
 	}
 
-	target := t.Interface()
-
 	switch derefKind {
 	case reflect.Struct, reflect.Array, reflect.Slice:
-		err := yaml.Unmarshal([]byte(str), &target)
+		target := dereferenced.Addr().Interface()
+		err := yaml.Unmarshal([]byte(str), target)
 
 		return target, err
 	case reflect.Map:
+		target := t.Interface()
 		err := yaml.Unmarshal([]byte(str), target)
 
 		return target, err
 	case reflect.Invalid:
 		// Try to decode string to any, it may work. If not, just return the value as-is
+		target := t.Interface()
 		err := yaml.Unmarshal([]byte(str), &target)
 		if err != nil {
 			return str, nil

--- a/mgc/core/config/config_test.go
+++ b/mgc/core/config/config_test.go
@@ -110,6 +110,10 @@ func TestGet(t *testing.T) {
 		Unmarshaler unmarshalerField `json:"unmarshaler"`
 	}
 
+	type unmarshalerSubObject struct {
+		Person unmarshalerPerson `json:"person"`
+	}
+
 	t.Run("decode to no pointer", func(t *testing.T) {
 		c, err := setupWithFile([]byte(`{ "foo": "bar" }`))
 
@@ -349,6 +353,36 @@ func TestGet(t *testing.T) {
 		}
 	})
 
+	t.Run("decode object in config file with subfield unmarshaler types", func(t *testing.T) {
+		// We save objects in Config File as strings...
+		data := `{
+			"foo": "{\"person\":{\"name\":\"jon\",\"age\":5,\"unmarshaler\":\"valid\"}}"
+		}`
+
+		expected := unmarshalerSubObject{
+			Person: unmarshalerPerson{
+				Name:        "jon",
+				Age:         5,
+				Unmarshaler: 100,
+			},
+		}
+
+		c, err := setupWithFile([]byte(data))
+
+		if err != nil {
+			t.Errorf("expected err == nil, found: %#v", err)
+		}
+
+		p := new(unmarshalerSubObject)
+		err = c.Get("foo", p)
+
+		if err != nil {
+			t.Errorf("expected err == nil, found: %#v", err)
+		}
+		if !reflect.DeepEqual(*p, expected) {
+			t.Errorf("expected p == %#v, found: %#v", expected, p)
+		}
+	})
 	t.Run("decode object in config file to any", func(t *testing.T) {
 		// We save objects in Config File as strings...
 		data := `{


### PR DESCRIPTION
We need to take the concrete address of the target variable via reflect's '.Addr()' function and use the returned interface directly, instead of taking the interface without 'Addr' and passing it via '&target'. The previous solution made it so that 'yaml.Unamrshal' could change the type of target as it pleased (it was always unmarshaling to 'any' instead of unmarshaling to the correct type)

## Related Issues

- Closes #484