### PR TITLE
fix(cli): only add array items constraints if not empty

### DIFF
--- a/mgc/cli/cmd/schema_constraints.go
+++ b/mgc/cli/cmd/schema_constraints.go
@@ -75,9 +75,10 @@ func addArrayConstraints(s *mgcSdk.Schema, dst *[]string) {
 		if filler, ok := getSchemaConstraintFiller(items.Type); ok {
 			itemsConstraints := []string{}
 			filler(items, &itemsConstraints)
-
-			itemsStr := fmt.Sprintf("%s:(%s)", items.Type, strings.Join(itemsConstraints, " and "))
-			*dst = append(*dst, itemsStr)
+			if len(itemsConstraints) > 0 {
+				itemsStr := fmt.Sprintf("%s:(%s)", items.Type, strings.Join(itemsConstraints, " and "))
+				*dst = append(*dst, itemsStr)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## How to test

Run `network port create-ports -h`

### Before

```
      --security-groups-id array(string)   (string:()) (default [])
      --server-url string                  Manually specify the server to use (format: uri)
      --subnets array(string)              (string:()) (default [])
```

### After

```
      --security-groups-id array(string)    (default [])
      --server-url string                  Manually specify the server to use (format: uri)
      --subnets array(string)               (default [])
```