### PR TITLE
feat(cli): inject persistent flags on root

### DIFF
--- a/mgc/cli/cmd/load_cmd_tree.go
+++ b/mgc/cli/cmd/load_cmd_tree.go
@@ -168,10 +168,11 @@ func addAction(
 		},
 	}
 
-	addFlags(actionCmd.Flags(), exec.ParametersSchema())
-	addFlags(actionCmd.PersistentFlags(), exec.ConfigsSchema())
-
 	parentCmd.AddCommand(actionCmd)
+
+	addFlags(actionCmd.Flags(), exec.ParametersSchema())
+	addFlags(actionCmd.Root().PersistentFlags(), exec.ConfigsSchema())
+
 	logger().Debugw("Executor added to command tree", "name", exec.Name())
 	// TODO: Parse this command's flags right after its creation
 	return actionCmd, nil
@@ -244,10 +245,10 @@ func addLink(
 		},
 	}
 
-	addFlags(linkCmd.Flags(), link.AdditionalParametersSchema())
-	addFlags(linkCmd.PersistentFlags(), link.AdditionalConfigsSchema())
-
 	parentCmd.AddCommand(linkCmd)
+	addFlags(linkCmd.Flags(), link.AdditionalParametersSchema())
+	addFlags(linkCmd.Root().PersistentFlags(), link.AdditionalConfigsSchema())
+
 	logger().Debugw("Link added to command tree", "name", link.Name())
 
 	// Reset values of persistent flags to avoid inheriting the values set from previous actions/links


### PR DESCRIPTION

<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

Currently, our Configs (Persistent Flags) are injected in the last command in the chain, created by the Executor. This means that they behave no differently than normal flags, but the cool thing about Persistent Flags is that they're valid no matter where they're inserted (vpc port --my-flag="some" get is equal to vpc port get --my-flag="some")

We need to set the persistent flags in the root command instead, and test whether they're working as intended (try setting config flags in the cli and see if they're being passed correctly)

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->
close #45

## Progress

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [ ] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

<!-- Describe how the reviewers can test your feature. -->

## Visual reference
<img width="1062" alt="Screenshot 2023-11-06 at 15 33 53" src="https://github.com/profusion/magalu/assets/6519791/aaae3131-c927-47b7-90cf-dd0c6e7a71b3">
