### PR TITLE
fix(cli): fix error when trying to load flag data

### DIFF
--- a/mgc/cli/cmd/load_cmd_tree.go
+++ b/mgc/cli/cmd/load_cmd_tree.go
@@ -152,7 +152,10 @@ func addAction(
 				return err
 			}
 
-			if err := loadDataFromConfig(config, cmd.PersistentFlags(), exec.ConfigsSchema(), configs); err != nil {
+			// Load from 'Flags' instead of 'PersistentFlags' because Cobra merges them before executing the command
+			// (and in other scenarios too). The canonical way to load the flags is always via cmd.Flags(), PersistentFlags
+			// are only to be used for inserting new flags
+			if err := loadDataFromConfig(config, cmd.Flags(), exec.ConfigsSchema(), configs); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
PersistentFlags in the command execution seem to be empty... But the
right way to load the flags from a command is through 'Flags()' anyway,
so this fixes that