### PR TITLE
feat: add recursive flag for object storage folder listing

### DIFF
--- a/mgc/sdk/static/object_storage/common/const.go
+++ b/mgc/sdk/static/object_storage/common/const.go
@@ -41,4 +41,6 @@ const (
 	CHUNK_SIZE = 1024 * 1024 * 5
 
 	ApiLimitMaxItems = 1000
+
+	delimiter = "/"
 )


### PR DESCRIPTION
## Description

This PR adds a `--recursive` flag to `object-storage objects list` in order to control how folders are listed. Providing the flag will make every file in the destination be listed, recursively. If it's not provided, any immediate folders within the destination will still be listed as part of  `"CommonPrefixes"`.

## Related Issues

- A part of #530

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Alternate between providing or not the `--recursive` flag to the `list` command and check how `"CommonPrefixes"` changes accordingly.

```
$ go run main.go object-storage objects list --dst test-bucket --recursive
...
{
 "CommonPrefixes": [],
 ...
}
```
```
$ go run main.go object-storage objects list --dst test-bucket
...
{
 "CommonPrefixes": [
  {
   "Path": "subdir/"
  }
 ],
 ...
}
```