### PR TITLE
fix(output/table): fix and standardize subtables

### DIFF
--- a/mgc/cli/cmd/output_table.go
+++ b/mgc/cli/cmd/output_table.go
@@ -317,7 +317,7 @@ func concreteKind(v reflect.Value) reflect.Kind {
 
 func columnsFromPointerOrInterface(v reflect.Value, prefix string) ([]*column, error) {
 	if v.IsNil() {
-		return []*column{{Name: "RESULT", JSONPath: prefix}}, nil
+		return []*column{{Name: "", JSONPath: prefix}}, nil
 	}
 
 	return columnsFromAny(v.Elem().Interface(), prefix)
@@ -343,7 +343,7 @@ func columnsFromStruct(v reflect.Value, prefix string) ([]*column, error) {
 
 func columnsFromArrayOrSlice(v reflect.Value, prefix string) ([]*column, error) {
 	if v.Len() == 0 {
-		return []*column{{Name: "RESULT", JSONPath: prefix}}, nil
+		return []*column{{Name: "", JSONPath: prefix}}, nil
 	}
 
 	subVal := v.Index(0)
@@ -419,7 +419,7 @@ func columnsFromAny(val any, prefix string) ([]*column, error) {
 	case reflect.Map:
 		return columnsFromMap(v, prefix)
 	default:
-		return []*column{{Name: "RESULT", JSONPath: prefix}}, nil
+		return []*column{{Name: "", JSONPath: prefix}}, nil
 	}
 }
 
@@ -501,11 +501,17 @@ func configureWriter(w table.Writer, options *tableOptions) {
 func buildTableHorizontally(writer table.Writer, val any, options *tableOptions) error {
 	columnCount := len(options.Columns)
 	headers := make(table.Row, columnCount)
+	isHeaderValid := false
 	for i, col := range options.Columns {
 		headers[i] = col.Name
+		if col.Name != "" {
+			isHeaderValid = true
+		}
 	}
 
-	writer.AppendHeader(headers)
+	if isHeaderValid {
+		writer.AppendHeader(headers)
+	}
 	configureWriter(writer, options)
 
 	rows := []table.Row{}


### PR DESCRIPTION
## Description

This PR makes all subtables use the same standard for rendering, renders them in both horizontal and vertical tables and fixes an issue where subtables for arrays would only render the first element

## Related Issues

- Closes #522

## How to test it

- Upload some objects to bucket x on `object storage`
- Upload at least one object to bucket x on subdir y on `object storage` (e.g. `--dst s3://x/y`)
- List the objects in that bucket using the `-o table` flag
- Check that everything is working normally

## Visual reference

Before | After
:-:|:-:
<img width="462" alt="image" src="https://github.com/profusion/magalu/assets/63523165/06a2657b-2329-459c-bdf3-6474074f0ff8"> | <img width="530" alt="image" src="https://github.com/profusion/magalu/assets/63523165/6947d00f-7357-41f6-90f9-e63fbf0e53fa">
