### PR TITLE
fix(cli): display ENUM values when the type is object

### DIFF
--- a/mgc/cli/cmd/schema_constraints.go
+++ b/mgc/cli/cmd/schema_constraints.go
@@ -102,6 +102,12 @@ func getSchemaJSONrepresentation(s *mgcSdk.Schema) string {
 			}
 
 			result += fmt.Sprintf("%s%s: %s", prefix, name, getSchemaJSONrepresentation((*mgcSdk.Schema)(prop.Value)))
+			if constraint := schemaValueConstraints((*mgcSdk.Schema)(prop.Value)); constraint != "" {
+				result += fmt.Sprintf(" (%s)", constraint)
+				if prop.Value.Default != "" {
+					result += fmt.Sprintf(" (default %s)", prop.Value.Default)
+				}
+			}
 			i++
 		}
 		result += " }"


### PR DESCRIPTION
## Description

Running `go run main.go dbaas instances create` would previously show:
```
      --volume object                   ({ size: number, type: string })
```
When it should have displayed:
```
      --volume object                   ({ size: number, type: string (one of CLOUD_NVME|CLOUD_HDD) (default CLOUD_NVME) })
```
Taking the `ENUM` values into account. This PR fixes that.

## Related Issues

- #531

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Verify the result for the following command
```
$ go run main.go dbaas instances create
...
      --volume object                   ({ size: number, type: string (one of CLOUD_NVME|CLOUD_HDD) (default CLOUD_NVME) })
...
```

