### PR TITLE
feat: hide cli flags by default

### DIFF
--- a/mgc/cli/cmd/root.go
+++ b/mgc/cli/cmd/root.go
@@ -52,6 +52,10 @@ can generate a command line on-demand for Rest manipulation`,
 	addHideProgressFlag(rootCmd)
 	addShowInternalFlag(rootCmd)
 
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Hidden = true })
+
+	addShowCliGlobalFlags(rootCmd)
+
 	// Immediately parse flags for root command because we'll access the global flags prior
 	// to calling Execute (which is when Cobra parses the flags)
 	_ = rootCmd.ParseFlags(argParser.MainArgs())
@@ -62,6 +66,10 @@ can generate a command line on-demand for Rest manipulation`,
 
 	if err = initLogger(sdk, getLogFilterFlag(rootCmd)); err != nil {
 		return err
+	}
+
+	if getShowCliGlobalFlags(rootCmd) {
+		rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) { f.Hidden = false })
 	}
 
 	rootCmd.AddCommand(newDumpTreeCmd(sdk))

--- a/mgc/cli/cmd/show_cli_globals.go
+++ b/mgc/cli/cmd/show_cli_globals.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const showCliGlobalFlags = "cli.show-cli-globals"
+
+func addShowCliGlobalFlags(cmd *cobra.Command) {
+	cmd.Root().PersistentFlags().Bool(
+		showCliGlobalFlags,
+		false,
+		"Show all CLI global flags on usage text",
+	)
+	f := cmd.Root().PersistentFlags().Lookup(showCliGlobalFlags)
+	f.NoOptDefVal = "true"
+}
+
+func getShowCliGlobalFlags(cmd *cobra.Command) bool {
+	value, err := cmd.Root().PersistentFlags().GetBool(showCliGlobalFlags)
+	if err != nil {
+		return false
+	}
+	return value
+}


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

Add `--cli.hide-cli-globals` flag

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

- Closes #502 

## Progress

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [ ] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [X] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

<!-- Describe how the reviewers can test your feature. -->

All three commands bellow should not show any `--cli.*` flag on usage:

```
go run . virtual-machine --cli.hide-cli-globals
```
```
go run . virtual-machine instances --cli.hide-cli-globals
```
```
go run . virtual-machine instances get --cli.hide-cli-globals
```