### PR TITLE
feat(object-storage): use batch in delete requests

### DIFF
--- a/mgc/sdk/static/object_storage/buckets/delete.go
+++ b/mgc/sdk/static/object_storage/buckets/delete.go
@@ -49,7 +49,7 @@ func delete(ctx context.Context, params deleteParams, cfg common.Config) (core.V
 		"cfg", cfg,
 	)
 
-	objErr, err := common.DeleteAllObjects(ctx, common.DeleteAllObjectsParams{BucketName: params.BucketName}, cfg)
+	objErr, err := common.DeleteAllObjects(ctx, common.DeleteAllObjectsParams{BucketName: params.BucketName, BatchSize: common.MaxBatchSize}, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/mgc/sdk/static/object_storage/common/const.go
+++ b/mgc/sdk/static/object_storage/common/const.go
@@ -42,5 +42,9 @@ const (
 
 	ApiLimitMaxItems = 1000
 
+	MaxBatchSize = 1000
+
+	minBatchSize = 1
+
 	delimiter = "/"
 )

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -16821,6 +16821,13 @@
       "name": "delete-all",
       "parameters": {
        "properties": {
+        "batch_size": {
+         "default": 1000,
+         "description": "Limit of items per batch to delete",
+         "maximum": 1000,
+         "minimum": 1,
+         "type": "integer"
+        },
         "bucket": {
          "description": "Name of the bucket to delete objects from",
          "type": "string"

--- a/script-qa/cli-help/object-storage/objects/delete-all/help.txt
+++ b/script-qa/cli-help/object-storage/objects/delete-all/help.txt
@@ -4,10 +4,11 @@ Usage:
   ./cli object-storage objects delete-all [bucket] [flags]
 
 Flags:
-      --bucket string    Name of the bucket to delete objects from
-      --exclude string   Filename pattern to exclude
-  -h, --help             help for delete-all
-      --include string   Filename pattern to include (default "*")
+      --batch-size integer   Limit of items per batch to delete (range: 1 - 1000) (default 1000)
+      --bucket string        Name of the bucket to delete objects from
+      --exclude string       Filename pattern to exclude
+  -h, --help                 help for delete-all
+      --include string       Filename pattern to include (default "*")
 
 Global Flags:
       --cli.show-cli-globals   Show all CLI global flags on usage text


### PR DESCRIPTION
## Description

This PR adds batch deletion for `object-storage objects delete-all` so that, instead of sending a new request for each object we want to delete, we group them in batches and send a single request for each batch.

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run `object-storage objects delete-all` with debug logs and verify that only batch requests (which should use the `POST` method, [according to the documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html)) are being sent instead of one request (`DELETE`) for each object to be deleted.