### PR TITLE
fix(auth): show key values after set

### DIFF
--- a/mgc/sdk/static/auth/objectstorage/set.go
+++ b/mgc/sdk/static/auth/objectstorage/set.go
@@ -40,6 +40,6 @@ func newSet() core.Executor {
 	)
 
 	return core.NewExecuteResultOutputOptions(executor, func(exec core.Executor, result core.Result) string {
-		return "template=Keys saved successfully\nAccessKeyId={{.AccessKeyId}}\nSecretAccessKey={{.SecretAccessKey}}\n"
+		return "template=Keys saved successfully\nAccessKeyId={{.access_key_id}}\nSecretAccessKey={{.secret_access_key}}\n"
 	})
 }


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

Key values were not being printed after `./mgc auth object-storage set`

## Progress

<!-- If your PR is WIP, use checkboxes to show that you did and what you have to do. For example:

- [x] New endpoint created;
- [ ] Update organizations;
- [x] Create tests;
-->

<!-- Also, don't forget to review your code before marking it as ready to merge -->

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run `./mgc auth object-storage set` and check if key values are being printed correctly