### PR TITLE
feat(cli): add human readable constraints to --flag=help

### DIFF
--- a/mgc/cli/cmd/schema_flags/desc.go
+++ b/mgc/cli/cmd/schema_flags/desc.go
@@ -88,7 +88,7 @@ func (d *SchemaFlagValueDesc) RawDefaultValue() string {
 	return string(data)
 }
 
-var flagDescriptionUsageRe = regexp.MustCompile("([^'\" ]+)=([^'\" ]+)")
+var flagDescriptionUsageRe = regexp.MustCompile("([^'\"` ]+)=([^'\"` ]+)")
 
 func (d SchemaFlagValueDesc) fixDescriptionFlagUsage(input string) string {
 	enumAsString := getEnumAsString(d.Schema)
@@ -172,5 +172,15 @@ func (d SchemaFlagValueDesc) Usage() (usage string) {
 		usage += fmt.Sprintf("Use --%s=%s for more details", d.FlagName, ValueHelpIsRequired)
 	}
 
+	return
+}
+
+func (d SchemaFlagValueDesc) HumanReadableConstraints() (c *HumanReadableConstraints) {
+	c = NewHumanReadableConstraints(d.Schema)
+	if c == nil {
+		return
+	}
+
+	c.Description = d.fixDescriptionFlagUsage(c.Description)
 	return
 }

--- a/mgc/cli/go.mod
+++ b/mgc/cli/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.8
 	github.com/stoewer/go-strcase v1.3.0
 	go.uber.org/zap v1.25.0
+	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63
 	golang.org/x/term v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	moul.io/zapfilter v1.7.0
@@ -61,7 +62,6 @@ require (
 	github.com/spf13/viper v1.16.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect


### PR DESCRIPTION
```
./cli virtual-machine instances create --network-interfaces=help
Flag usage:
    --network-interfaces=array(object)

Description:
    Network Interfaces (Array value). Array where each item is: NetworkID (Object value). Object with the following properties: "id": Id (String value).
```

```
./cli  mke cluster create --param.version=help
Flag usage:
    --param.version=enum

Description:
    Versão do kubernetes nativa do cluster. One of the values:
      - "v1.22.9"
      - "v1.24.10"
      - "v1.26.1"
      - "v1.28.2" (default value)
```

but it doesn't do magic, this one is still hard to read:
```
./cli mke cluster create --node-pools=help   
Flag usage:
    --node-pools=array(object)

Description:
    Conjunto de nodes em um cluster kubernetes (Array value). Array where each item is: Objeto da requisição da request do nodepool (Object value). Object with the following properties:
          - "flavor": (required) Definição da capacidade de CPU, memória RAM e armazenamento dos nodes
            | <table>
            |   <tr>
            |     <td>Flavor</td>
            |     <td>vCPUs</td>
            |     <td>RAM(Gb)</td>
            |     <td>Root Disk(GB)</td>
            |   </tr>
            |   <tr>
            |     <td>cloud-k8s.gp1.small</td>
            |     <td>2</td>
            |     <td>4</td>
            |     <td>20</td>
            |   </tr>
            |   <tr>
            |     <td>cloud-k8s.gp1.large</td>
            |     <td>8</td>
            |     <td>16</td>
            |     <td>100</td>
            |   </tr>
            | </table>.
            One of the values:
              - "cloud-k8s.gp1.large"
              - "cloud-k8s.gp1.small"
          - "tags": Lista de tags aplicadas ao nodepool (Array value). Array where each item is: Items da lista de tags aplicadas ao nodepool (String value). Example value: "tag-value1"
          - "taints": Propriedade de associação de um conjunto se nós (Array value). Array where each item is: Object value. Object with the following properties:
                  - "effect": (required) O efeito do taint em pods que não toleram o taint.
                    | **NoSchedule** - Não permitir que novos pods sejam agendados no nó, a menos que eles tolerem a taint, mas permitir que todos os pods já em execução continuem em execução.
                    | **PreferNoSchedule** - Parecido com o NoSchedule, mas tenta não agendar novos pods no nó, em vez de proibir totalmente o agendamento de novos pods no nó
                    | **NoExecute** - Remova todos os pods já em execução que não tolerem o taint.
                    One of the values:
                      - "NoExecute"
                      - "NoSchedule"
                      - "PreferNoSchedule"
                  - "key": (required) A chave taint a ser aplicada ao node (String value). Example value: "exemplo-key"
                  - "value": (required) O valor correspondente a chave taint (String value). Example value: "valor1"
          - "replicas": (required) Número de réplicas dos nós do nodepool (Integer value).
              - If no value is provided, then 1 is used.
              - Example value: 3.
          - "auto_scale": Objeto que define propriedades para atualização de recursos da carga de trabalho do cluster kubernetes (Object value). Object with the following properties:
                - "enabled": (required) Ativa/Desativa o escalonamento automático (Boolean value).
                    - If no value is provided, then false is used.
                    - Example value: true.
                - "max_replicas": (required) Quantidade máxima de réplicas, caso a função de autoscaling esteja habilitada (Integer value). With the following constraints:
                    - min: 1.
                    - If no value is provided, then 1 is used.
                    - Example value: 5.
                - "min_replicas": (required) Quantidade mínima  de réplicas, caso a função de autoscaling esteja habilitada (Integer value). With the following constraints:
                    - min: 1.
                    - If no value is provided, then 1 is used.
                    - Example value: 2.
          - "name": (required) Nome do node pool. O nome destina-se principalmente à idempotência, e deve ser exclusivo em um namespace. 0 nome não pode ser alterado.
            | O nome deve seguir as seguintes regras:
            |   - deve conter no máximo 63 caracteres
            |   - deve conter apenas caracteres alfanuméricos minúsculos ou '-'
            |   - deve começar com um caractere alfabético
            |   - deve terminar com um caractere alfanumérico (String value).
            Example value: "nodepool-exemplo"
```
