### PR TITLE
refactor: config tests

### DIFF
--- a/mgc/core/config/config_test.go
+++ b/mgc/core/config/config_test.go
@@ -6,75 +6,36 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/spf13/afero"
 	"magalu.cloud/core/profile_manager"
+	"magalu.cloud/core/utils"
+	"magalu.cloud/testing/fs_test_helper"
 )
 
-type test struct {
-	key      string
-	fileData []byte
-	expected any
+type testCaseConfig struct {
+	name       string
+	run        func(c *Config) error
+	expectedFs []fs_test_helper.TestFsEntry
+	providedFs []fs_test_helper.TestFsEntry
 }
 
-func setupWithoutFile() *Config {
-	pf, _ := profile_manager.NewInMemoryProfileManager()
+func setupWithoutFile(path string) (*Config, afero.Fs) {
+	pf, fs := profile_manager.NewInMemoryProfileManager()
 	c := New(pf)
 	c.init()
 
-	return c
+	return c, fs
 }
 
-func setupWithFile(testFileData []byte) (*Config, error) {
-	m, _ := profile_manager.NewInMemoryProfileManager()
+func setupWithFile(testFileData []byte, path string) (*Config, error, afero.Fs) {
+	m, fs := profile_manager.NewInMemoryProfileManager()
 	if err := m.Current().Write(CONFIG_FILE, testFileData); err != nil {
-		return nil, err
+		return nil, err, fs
 	}
 
 	c := New(m)
 
-	return c, nil
-}
-
-func TestGetWithoutFile(t *testing.T) {
-	tests := []test{
-		{key: "foo", fileData: []byte{}, expected: nil},
-	}
-
-	for _, tc := range tests {
-		c := setupWithoutFile()
-
-		var out any
-		if err := c.Get(tc.key, &out); err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-
-		if out != tc.expected {
-			t.Errorf("expected %#v, found %#v", tc.expected, out)
-		}
-	}
-}
-
-func TestGetWithFile(t *testing.T) {
-	tests := []test{
-		{key: "foo", fileData: []byte(`foo: bar`), expected: "bar"},
-		{key: "foo", fileData: []byte(`foo:`), expected: nil},
-		{key: "foo", fileData: []byte(``), expected: nil},
-	}
-
-	for _, tc := range tests {
-		c, err := setupWithFile(tc.fileData)
-		if err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-
-		var out any
-		if err := c.Get(tc.key, &out); err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-
-		if out != tc.expected {
-			t.Errorf("expected %#v, found %#v", tc.expected, out)
-		}
-	}
+	return c, nil, fs
 }
 
 type unmarshalerField int
@@ -106,8 +67,9 @@ func TestGet(t *testing.T) {
 		Person unmarshalerPerson `json:"person"`
 	}
 
+	fsPath := "/"
 	t.Run("decode to no pointer", func(t *testing.T) {
-		c, err := setupWithFile([]byte(`{ "foo": "bar" }`))
+		c, err, _ := setupWithFile([]byte(`{ "foo": "bar" }`), fsPath)
 
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
@@ -122,7 +84,7 @@ func TestGet(t *testing.T) {
 	})
 
 	t.Run("decode to nil pointer", func(t *testing.T) {
-		c, err := setupWithFile([]byte(`{ "foo": "bar" }`))
+		c, err, _ := setupWithFile([]byte(`{ "foo": "bar" }`), fsPath)
 
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
@@ -138,7 +100,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("decode partial to non-zero struct", func(t *testing.T) {
 		data := `{"person":{"name":"Josh"}}`
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 		if err != nil {
 			t.Errorf("setting up file expected err == nil, found: %#v", err)
 		}
@@ -165,7 +127,7 @@ func TestGet(t *testing.T) {
 		}`
 		expected := person{Name: "jon", Age: 5, CaseSensitive: "some"}
 
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
@@ -194,7 +156,7 @@ func TestGet(t *testing.T) {
 
 		t.Setenv("MGC_FOO", data)
 
-		c := setupWithoutFile()
+		c, _ := setupWithoutFile(fsPath)
 
 		p := new(person)
 		err := c.Get("foo", p)
@@ -211,7 +173,7 @@ func TestGet(t *testing.T) {
 		data := `{ "foo": "bar" }`
 		expected := "bar"
 
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
 		}
@@ -231,7 +193,7 @@ func TestGet(t *testing.T) {
 		expected := "bar"
 		t.Setenv("MGC_FOO", expected)
 
-		c := setupWithoutFile()
+		c, _ := setupWithoutFile(fsPath)
 
 		var p string
 		err := c.Get("foo", &p)
@@ -254,7 +216,7 @@ func TestGet(t *testing.T) {
 		}`
 		expected := person{Name: "jon", Age: 5, CaseSensitive: "some"}
 
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
@@ -283,7 +245,7 @@ func TestGet(t *testing.T) {
 
 		t.Setenv("MGC_FOO", data)
 
-		c := setupWithoutFile()
+		c, _ := setupWithoutFile(fsPath)
 
 		var p person
 		err := c.Get("foo", &p)
@@ -300,7 +262,7 @@ func TestGet(t *testing.T) {
 		data := `{ "foo": "bar" }`
 		expected := "bar"
 
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
 		}
@@ -328,7 +290,7 @@ func TestGet(t *testing.T) {
 			Unmarshaler: 100,
 		}
 
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
@@ -359,7 +321,7 @@ func TestGet(t *testing.T) {
 			},
 		}
 
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
@@ -387,7 +349,7 @@ func TestGet(t *testing.T) {
 			"caseSensitive": "some",
 		}
 
-		c, err := setupWithFile([]byte(data))
+		c, err, _ := setupWithFile([]byte(data), fsPath)
 
 		if err != nil {
 			t.Errorf("expected err == nil, found: %#v", err)
@@ -409,7 +371,7 @@ func TestGet(t *testing.T) {
 
 		t.Setenv("MGC_FOO", expected)
 
-		c := setupWithoutFile()
+		c, _ := setupWithoutFile(fsPath)
 
 		var p any
 		err := c.Get("foo", &p)
@@ -437,7 +399,7 @@ func TestGet(t *testing.T) {
 			"caseSensitive": "some",
 		}
 
-		c := setupWithoutFile()
+		c, _ := setupWithoutFile(fsPath)
 
 		var p any
 		err := c.Get("foo", &p)
@@ -451,102 +413,239 @@ func TestGet(t *testing.T) {
 	})
 }
 
-func TestSetWithoutFile(t *testing.T) {
-	tests := []test{
-		{key: "foo", fileData: []byte{}, expected: "woo"},
-	}
-
-	for _, tc := range tests {
-		c := setupWithoutFile()
-
-		if err := c.Set(tc.key, tc.expected); err != nil {
-			t.Errorf("expected err == nil , found %#v", err)
-		}
-
-		var v any
-		if err := c.Get(tc.key, &v); err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-		if v != tc.expected {
-			t.Errorf("expected %#v, found %#v", tc.expected, v)
-		}
+func deleteTest(name string, key string, expected any, provided []fs_test_helper.TestFsEntry, expectedfs []fs_test_helper.TestFsEntry) testCaseConfig {
+	provided = fs_test_helper.AutoMkdirAll(provided)
+	expectedfs = fs_test_helper.AutoMkdirAll(expectedfs)
+	return testCaseConfig{
+		name:       fmt.Sprintf("Config.DeleteWithFile(%q)", name),
+		providedFs: provided,
+		expectedFs: expectedfs,
+		run: func(c *Config) error {
+			return c.Delete(key)
+		},
 	}
 }
 
-func TestSetWithFile(t *testing.T) {
-	tests := []test{
-		{key: "foo", fileData: []byte("foo: bar"), expected: "woo"},
-		{key: "foo", fileData: []byte("foo:"), expected: "woo"},
-		{key: "foo", fileData: []byte(""), expected: "woo"},
-	}
+func getTest(name string, key string, expected any, provided []fs_test_helper.TestFsEntry, expectedfs []fs_test_helper.TestFsEntry) testCaseConfig {
+	provided = fs_test_helper.AutoMkdirAll(provided)
+	expectedfs = fs_test_helper.AutoMkdirAll(expectedfs)
+	return testCaseConfig{
+		name:       fmt.Sprintf("Config.Get(%q)", name),
+		providedFs: provided,
+		expectedFs: expectedfs,
+		run: func(c *Config) error {
+			var out any
+			if err := c.Get(key, &out); err != nil {
+				return fmt.Errorf("expected err == nil, found: %#v", err)
+			}
 
-	for _, tc := range tests {
-		c, err := setupWithFile(tc.fileData)
-		if err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-
-		if err := c.Set(tc.key, tc.expected); err != nil {
-			t.Errorf("expected err == nil , found %#v", err)
-		}
-
-		var v any
-		if err := c.Get(tc.key, &v); err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-		if v != tc.expected {
-			t.Errorf("expected %#v, found %#v", tc.expected, v)
-		}
+			if out != expected {
+				return fmt.Errorf("expected %#v, found %#v", expected, out)
+			}
+			return nil
+		},
 	}
 }
 
-func TestDeleteWithoutFile(t *testing.T) {
-	tests := []test{
-		{key: "foo", fileData: []byte("foo: bar"), expected: nil},
-		{key: "foo", fileData: []byte("foo:"), expected: nil},
-		{key: "foo", fileData: []byte(""), expected: nil},
-	}
+func setTest(name string, key string, expected any, provided []fs_test_helper.TestFsEntry, expectedfs []fs_test_helper.TestFsEntry) testCaseConfig {
+	provided = fs_test_helper.AutoMkdirAll(provided)
+	expectedfs = fs_test_helper.AutoMkdirAll(expectedfs)
+	return testCaseConfig{
+		name:       fmt.Sprintf("Config.SetWithFile(%q)", name),
+		providedFs: provided,
+		expectedFs: expectedfs,
+		run: func(c *Config) error {
+			return c.Set(key, expected)
 
-	for _, tc := range tests {
-		c := setupWithoutFile()
-
-		if err := c.Delete(tc.key); err != nil {
-			t.Errorf("expected err == nil, found %#v", err)
-		}
-
-		var v any
-		if err := c.Get(tc.key, &v); err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-		if v != tc.expected {
-			t.Errorf("expected %#v, found %#v", tc.expected, v)
-		}
+		},
 	}
 }
 
-func TestDeleteWithFile(t *testing.T) {
-	tests := []test{
-		{key: "foo", fileData: []byte("foo: bar"), expected: nil},
-		{key: "foo", fileData: []byte("foo:"), expected: nil},
-		{key: "foo", fileData: []byte(""), expected: nil},
+func TestConfigManagerWithFile(t *testing.T) {
+	tests := []testCaseConfig{
+		deleteTest("test1", "foo", nil,
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: bar`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`{}
+`),
+				},
+			}),
+		deleteTest("test2", "foo", nil,
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo:`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo:`),
+				},
+			}),
+		deleteTest("test3", "foo", nil,
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte{},
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte{},
+				},
+			}),
+		deleteTest("withoutFile3", "foo", nil,
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`""`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`""`),
+				},
+			}),
+
+		getTest("test1", "foo", "bar",
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: bar`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: bar`),
+				},
+			}),
+		getTest("test2", "foo", nil,
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo`),
+				},
+			}),
+		getTest("test3", "foo", nil,
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`""`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`""`),
+				},
+			}),
+		setTest("test1", "foo", "woo",
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: bar`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: woo
+`),
+				},
+			}),
+
+		setTest("test2", "foo", "woo",
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo:`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: woo
+`),
+				},
+			}),
+		setTest("test3", "foo", "woo",
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`""`),
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: woo
+`),
+				},
+			}),
+		setTest("test1", "foo", "woo",
+			[]fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/",
+					Mode: utils.DIR_PERMISSION,
+					Data: []byte{},
+				},
+			}, []fs_test_helper.TestFsEntry{
+				{
+					Path: "/default/cli.yaml",
+					Mode: utils.FILE_PERMISSION,
+					Data: []byte(`foo: woo
+`)},
+			}),
 	}
 
 	for _, tc := range tests {
-		c, err := setupWithFile(tc.fileData)
-		if err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
+		t.Run(tc.name, func(t *testing.T) {
 
-		if err := c.Delete(tc.key); err != nil {
-			t.Errorf("expected err == nil, found %#v", err)
-		}
+			m, fs := profile_manager.NewInMemoryProfileManager()
+			fs_err := fs_test_helper.PrepareFs(fs, tc.providedFs)
 
-		var v any
-		if err := c.Get(tc.key, &v); err != nil {
-			t.Errorf("expected err == nil, found: %#v", err)
-		}
-		if v != tc.expected {
-			t.Errorf("expected %#v, found %#v", tc.expected, v)
-		}
+			if fs_err != nil {
+				t.Errorf("could not prepare provided FS: %s", fs_err.Error())
+			}
+			c := New(m)
+			run_error := tc.run(c)
+
+			if run_error != nil {
+				t.Errorf("expected err == nil, found: %v", run_error)
+			}
+
+			fs_err = fs_test_helper.CheckFs(fs, tc.expectedFs)
+
+			if fs_err != nil {
+				t.Errorf("unexpected FS state: %s", fs_err.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description
Refactoring config tests to a more readable and maintainable structure

## Related Issues
- Closes #593 

## Note
- I used some commits from [auth tests refactor](https://github.com/profusion/magalu/pull/574). I did it because i need to use the fs helpers.
- We agreed not to refactor all the tests, as it's not a high priority and the get test unit has a number of cases that don't just vary the inputs, so it can't be defined as a single function like the other cases. 