### PR TITLE
fix(links): access and read linked command flags properly

### DIFF
--- a/mgc/cli/cmd/link_cmd.go
+++ b/mgc/cli/cmd/link_cmd.go
@@ -171,8 +171,9 @@ func (c *cmdLinks) handle(originalResult core.Result, parentOutputFlag string) (
 		return
 	}
 
-	setOutputFlag(c.root, parentOutputFlag)
-	err = c.root.ParseFlags(args)
+	cmd := c.resolvedCmd
+	setOutputFlag(cmd, parentOutputFlag)
+	err = cmd.ParseFlags(args[1:])
 	if err != nil {
 		logger().Debugw("could not parse link flags", "args", args, "error", err, "link", link.Name())
 		return


### PR DESCRIPTION
## Description

Previously, when passing a link to a command such as `block-storage volume get <id> ! update --name="link-fix-test-edited"`, the `update` part and the `--name="link-fix-test-edited"` would be treated as separate elements. As a consequence, the `update` command wouldn't work because the `name` part was considered to be missing from it. We fix this by joining both together when handling the link.

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Sample command: `go run . block-storage volume create --name="link-fix-test-3" --description="Link fix test" --size=20 --volume-type="cloud_nvme" ! read -w ! update --name="link-fix-test-edited" ! read -w`