### PR TITLE
fix: fixing error message

### DIFF
--- a/mgc/sdk/static/object_storage/common/session.go
+++ b/mgc/sdk/static/object_storage/common/session.go
@@ -42,7 +42,7 @@ func SendRequest(ctx context.Context, req *http.Request) (res *http.Response, er
 
 	accesskeyId, accessSecretKey := auth.FromContext(ctx).AccessKeyPair()
 	if accesskeyId == "" || accessSecretKey == "" {
-		err = fmt.Errorf("access key not set, see how to set it with \"auth set -h\"")
+		err = fmt.Errorf("access key not set, see how to set it with \"auth object-storage set -h\"")
 		return
 	}
 


### PR DESCRIPTION
## Description
Attempting to run object store commands without setting the access key resulted in an error and a helper stating
to run `auth set -h` to see how to set it, which is an invalid command. So this PR is just adding the right command