### PR TITLE
fix(auth): don't choose tenants when logging in

### DIFF
--- a/mgc/core/auth/auth.go
+++ b/mgc/core/auth/auth.go
@@ -228,7 +228,9 @@ func (o *Auth) CodeChallengeToURL() (*url.URL, error) {
 	query.Add("code_challenge", o.codeVerifier.CodeChallengeS256())
 	query.Add("code_challenge_method", "S256")
 	query.Add("scope", strings.Join(config.Scopes, " "))
-	query.Add("choose_tenants", "true")
+	// TODO: Set choose tenants to true, and parse resulting token to get the selected tenant,
+	// then set it. For now, just leave the tenant as the default one
+	// query.Add("choose_tenants", "true")
 
 	loginUrl.RawQuery = query.Encode()
 


### PR DESCRIPTION
This is a temporary fix for the flow to make sense. A proper handling of the tenants will be implemented ASAP, parsing the token, getting the selected tenant, setting it, etc