### PR TITLE
fix(object-storage): remove pagination params from download-all

### DIFF
--- a/mgc/sdk/static/object_storage/objects/download_all.go
+++ b/mgc/sdk/static/object_storage/objects/download_all.go
@@ -26,10 +26,9 @@ func downloadAllLogger() *zap.SugaredLogger {
 }
 
 type downloadAllObjectsParams struct {
-	Source                  mgcSchemaPkg.URI      `json:"src" jsonschema:"description=Path of objects to be downloaded,example=s3://mybucket/" mgc:"positional"`
-	Destination             mgcSchemaPkg.FilePath `json:"dst,omitempty" jsonschema:"description=Path to save files,example=path/to/folder" mgc:"positional"`
-	common.FilterParams     `json:",squash"`      // nolint
-	common.PaginationParams `json:",squash"`      // nolint
+	Source              mgcSchemaPkg.URI      `json:"src" jsonschema:"description=Path of objects to be downloaded,example=s3://mybucket/" mgc:"positional"`
+	Destination         mgcSchemaPkg.FilePath `json:"dst,omitempty" jsonschema:"description=Path to save files,example=path/to/folder" mgc:"positional"`
+	common.FilterParams `json:",squash"`      // nolint
 }
 
 var getDownloadAll = utils.NewLazyLoader[core.Executor](func() core.Executor {
@@ -74,7 +73,7 @@ func downloadMultipleFiles(ctx context.Context, cfg common.Config, params downlo
 		objs = pipeline.Filter[pipeline.WalkDirEntry](ctx, objs, excludeFilter)
 	}
 
-	entries, err := pipeline.SliceItemLimitedConsumer[[]pipeline.WalkDirEntry](ctx, params.MaxItems, objs)
+	entries, err := pipeline.SliceItemConsumer[[]pipeline.WalkDirEntry](ctx, objs)
 	if err != nil {
 		return err
 	}
@@ -148,7 +147,6 @@ func downloadAll(ctx context.Context, p downloadAllObjectsParams, cfg common.Con
 		return nil, fmt.Errorf("no destination specified and could not use local dir: %w", err)
 	}
 	p.Destination = dst
-	p.MaxItems = math.MaxInt64
 	err = downloadMultipleFiles(ctx, cfg, p)
 
 	if err != nil {

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -16887,10 +16887,6 @@
       "name": "download-all",
       "parameters": {
        "properties": {
-        "continuation-token": {
-         "description": "Token of result page to continue from",
-         "type": "string"
-        },
         "dst": {
          "description": "Path to save files",
          "example": "path/to/folder",
@@ -16905,13 +16901,6 @@
          "default": "*",
          "description": "Filename pattern to include",
          "type": "string"
-        },
-        "max-items": {
-         "default": 1000,
-         "description": "Limit of items to be listed",
-         "example": 1000,
-         "minimum": 1,
-         "type": "integer"
         },
         "src": {
          "description": "Path of objects to be downloaded",

--- a/script-qa/cli-help/object-storage/objects/download-all/help.txt
+++ b/script-qa/cli-help/object-storage/objects/download-all/help.txt
@@ -4,16 +4,14 @@ Usage:
   ./cli object-storage objects download-all [src] [dst] [flags]
 
 Examples:
-  ./cli object-storage objects download-all --dst="path/to/folder" --max-items=1000 --src="s3://mybucket/"
+  ./cli object-storage objects download-all --dst="path/to/folder" --src="s3://mybucket/"
 
 Flags:
-      --continuation-token string   Token of result page to continue from
-      --dst file                    Path to save files
-      --exclude string              Filename pattern to exclude
-  -h, --help                        help for download-all
-      --include string              Filename pattern to include (default "*")
-      --max-items integer           Limit of items to be listed (min: 1) (default 1000)
-      --src uri                     Path of objects to be downloaded (required)
+      --dst file         Path to save files
+      --exclude string   Filename pattern to exclude
+  -h, --help             help for download-all
+      --include string   Filename pattern to include (default "*")
+      --src uri          Path of objects to be downloaded (required)
 
 Global Flags:
       --cli.show-cli-globals   Show all CLI global flags on usage text


### PR DESCRIPTION
## Description

Pagination parameters seem to be unnecessary for the purposes of the download-all operation. This PR removes them.

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run `go run . object-storage objects download-all` and check that the pagination parameters no longer show up. Also run the full command to check that `download-all` is still working.