### PR TITLE
fix(object-storage): log list request error as warning

### DIFF
--- a/mgc/sdk/static/object_storage/common/list.go
+++ b/mgc/sdk/static/object_storage/common/list.go
@@ -226,7 +226,7 @@ func ListGenerator(ctx context.Context, params ListObjectsParams, cfg Config) (o
 			}
 
 			if err != nil {
-				logger.Errorw("list request failed", "err", err, "req", req)
+				logger.Warnw("list request failed", "err", err, "req", (*mgcHttpPkg.LogRequest)(req))
 				select {
 				case <-ctx.Done():
 					logger.Debugw("context.Done()", "err", err)


### PR DESCRIPTION
## Description

This PR changes the error log when a list request fails to a warning. It also casts the request to properly serialize JSON, to avoid a `json: unsupported type` message in the log.

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Any list request errors from a command such as `go run . object-storage objects list` should now show up as a warning without a `json: unsupported type` error.