### PR TITLE
fix: demote validation err log level on releases

### DIFF
--- a/mgc/cli/cmd/cmd_result_format.go
+++ b/mgc/cli/cmd/cmd_result_format.go
@@ -55,7 +55,7 @@ func handleResultWithValue(result core.ResultWithValue, output string) (err erro
 
 	err = result.ValidateSchema()
 	if err != nil {
-		logger().Warnw("result validation failed", "error", err.Error())
+		logValidationErr(err)
 	}
 
 	name, options := parseOutputFormatter(output)

--- a/mgc/cli/cmd/log_validation_error_development.go
+++ b/mgc/cli/cmd/log_validation_error_development.go
@@ -1,0 +1,7 @@
+//go:build !release
+
+package cmd
+
+func logValidationErr(e error) {
+	logger().Warn("result validation failed", "error", e.Error())
+}

--- a/mgc/cli/cmd/log_validation_error_release.go
+++ b/mgc/cli/cmd/log_validation_error_release.go
@@ -1,0 +1,7 @@
+//go:build release
+
+package cmd
+
+func logValidationErr(e error) {
+	logger().Debugw("result validation failed", "error", e.Error())
+}


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

While we don't want validation erros on the releases sent to Magalu, they are important for developers to know which specs need fixes.

This PR fixes this by demoting validation error log level to `DEBUG` with builds containing the `release` build tag

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

- Closes #684 

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [x] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

<!-- Describe how the reviewers can test your feature. -->

- Should show validation error warnings:
```
build -o mgc
./mgc dbaas instances list
```

- Should NOT show any validation error warnings:
```
build -o mgc -tags release
./mgc dbaas instances list
```
