### PR TITLE
feat(object-storage): add copy operation

### DIFF
--- a/mgc/sdk/static/object_storage/objects/copy.go
+++ b/mgc/sdk/static/object_storage/objects/copy.go
@@ -1,0 +1,74 @@
+package objects
+
+import (
+	"context"
+	"net/http"
+
+	"magalu.cloud/core"
+	"magalu.cloud/core/progress_report"
+	mgcSchemaPkg "magalu.cloud/core/schema"
+	"magalu.cloud/core/utils"
+	"magalu.cloud/sdk/static/object_storage/common"
+)
+
+type copyObjectParams struct {
+	Source      mgcSchemaPkg.URI `json:"src" jsonschema:"description=Path of the object to be copied,example=s3://bucket1/file.txt" mgc:"positional"`
+	Destination mgcSchemaPkg.URI `json:"dst" jsonschema:"description=Full destination path in the bucket with desired filename,example=s3://bucket2/dir/file.txt" mgc:"positional"`
+}
+
+var getCopy = utils.NewLazyLoader[core.Executor](func() core.Executor {
+	executor := core.NewStaticExecute(
+		core.DescriptorSpec{
+			Name:        "copy",
+			Description: "Copy an object from a bucket to another",
+		},
+		copy,
+	)
+
+	return core.NewExecuteResultOutputOptions(executor, func(exec core.Executor, result core.Result) string {
+		return "template=Copied from {{.src}} to {{.dst}}\n"
+	})
+})
+
+func newCopyRequest(ctx context.Context, cfg common.Config, dst mgcSchemaPkg.URI) (*http.Request, error) {
+	host, err := common.BuildBucketHostWithPath(cfg, common.NewBucketNameFromURI(dst), dst.Path())
+	if err != nil {
+		return nil, core.UsageError{Err: err}
+	}
+	return http.NewRequestWithContext(ctx, http.MethodPut, string(host), nil)
+}
+
+func copySingleFile(ctx context.Context, cfg common.Config, src mgcSchemaPkg.URI, dst mgcSchemaPkg.URI) error {
+	req, err := newCopyRequest(ctx, cfg, dst)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("x-amz-copy-source", src.String())
+
+	_, err = common.SendRequest(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func copy(ctx context.Context, p copyObjectParams, cfg common.Config) (result core.Value, err error) {
+	reportProgress := progress_report.FromContext(ctx)
+	reportMsg := "Copying object from " + p.Source.String() + " to " + p.Destination.String()
+	progress := uint64(0)
+	total := uint64(1)
+
+	reportProgress(reportMsg, progress, total, progress_report.UnitsNone, nil)
+
+	err = copySingleFile(ctx, cfg, p.Source, p.Destination)
+	if err != nil {
+		reportProgress(reportMsg, progress, total, progress_report.UnitsNone, err)
+		return nil, err
+	}
+
+	reportProgress(reportMsg, total, total, progress_report.UnitsNone, progress_report.ErrorProgressDone)
+
+	return copyObjectParams{Source: p.Source, Destination: p.Destination}, err
+}

--- a/mgc/sdk/static/object_storage/objects/group.go
+++ b/mgc/sdk/static/object_storage/objects/group.go
@@ -13,6 +13,7 @@ var GetGroup = utils.NewLazyLoader[core.Grouper](func() core.Grouper {
 		},
 		func() []core.Descriptor {
 			return []core.Descriptor{
+				getCopy(),        // object-storage objects copy
 				getDelete(),      // object-storage objects delete
 				getDeleteAll(),   // object-storage objects delete-all
 				getDownload(),    // object-storage objects download

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -16883,6 +16883,86 @@
        },
        "type": "object"
       },
+      "description": "Copy an object from a bucket to another",
+      "isInternal": false,
+      "name": "copy",
+      "parameters": {
+       "properties": {
+        "dst": {
+         "description": "Full destination path in the bucket with desired filename",
+         "example": "s3://bucket2/dir/file.txt",
+         "format": "uri",
+         "type": "string"
+        },
+        "src": {
+         "description": "Path of the object to be copied",
+         "example": "s3://bucket1/file.txt",
+         "format": "uri",
+         "type": "string"
+        }
+       },
+       "required": [
+        "src",
+        "dst"
+       ],
+       "type": "object"
+      },
+      "result": {
+       "anyOf": [
+        {
+         "nullable": true,
+         "type": "null"
+        },
+        {
+         "type": "boolean"
+        },
+        {
+         "type": "string"
+        },
+        {
+         "type": "number"
+        },
+        {
+         "type": "integer"
+        },
+        {
+         "type": "array"
+        },
+        {
+         "additionalProperties": true,
+         "type": "object"
+        }
+       ],
+       "nullable": true
+      },
+      "version": ""
+     },
+     {
+      "configs": {
+       "properties": {
+        "region": {
+         "default": "br-ne-1",
+         "description": "Region to reach the service",
+         "enum": [
+          "br-ne-1",
+          "br-se-1"
+         ],
+         "type": "string"
+        },
+        "serverUrl": {
+         "description": "Manually specify the server to use",
+         "format": "uri",
+         "type": "string"
+        },
+        "workers": {
+         "default": 5,
+         "description": "Number of routines that spawn to do parallel operations within object_storage",
+         "minimum": 1,
+         "type": "integer"
+        }
+       },
+       "type": "object"
+      },
       "description": "Delete an object from a bucket",
       "isInternal": false,
       "name": "delete",

--- a/script-qa/cli-help/object-storage/objects/help.txt
+++ b/script-qa/cli-help/object-storage/objects/help.txt
@@ -5,6 +5,7 @@ Usage:
   ./cli object-storage objects [command]
 
 Commands:
+  copy         Copy an object from a bucket to another
   delete       Delete an object from a bucket
   delete-all   Delete all objects from a bucket
   download     download an object from a bucket


### PR DESCRIPTION
## Description

This PR adds an operation to copy a file from one bucket to another.

## Related Issues

- #701

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run `go run . object-storage objects copy` and follow the example. Then use `go run . object-storage objects list` for both the source and destination buckets in order to check that the file is present in both of them now.