### PR TITLE
fix(object-storage): handle prefix on copy request header

### DIFF
--- a/mgc/sdk/static/object_storage/objects/copy.go
+++ b/mgc/sdk/static/object_storage/objects/copy.go
@@ -2,7 +2,9 @@ package objects
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"magalu.cloud/core"
 	"magalu.cloud/core/progress_report"
@@ -44,7 +46,12 @@ func copySingleFile(ctx context.Context, cfg common.Config, src mgcSchemaPkg.URI
 		return err
 	}
 
-	req.Header.Set("x-amz-copy-source", src.String())
+	copySource, err := url.JoinPath(src.Hostname(), src.Path())
+	if err != nil {
+		return core.UsageError{Err: fmt.Errorf("badly specified source URI: %w", err)}
+	}
+
+	req.Header.Set("x-amz-copy-source", copySource)
 
 	_, err = common.SendRequest(ctx, req)
 	if err != nil {


### PR DESCRIPTION
## Description

The `x-amz-copy-source` header for copy requests does not accept the `s3://` URI prefix, so this PR removes it.

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Run `go run . object-storage objects copy` with different combinations of `s3://` in the source and destination URIs.
