### PR TITLE
Fixes on create links script

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -252,7 +252,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -260,15 +259,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -285,7 +277,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -293,7 +284,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -537,4 +527,4 @@ tests = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2ed8fd61abb2a8b728a7057525c46e82e794b6991adbd0368eec8f20adbbf087"
+content-hash = "6ae74e42cb62d39a5b414eb669b3194755ec5e724bfba7e1767f4c0cf8c63edb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = "^3.11"
 pyyaml = "^6.0.1"
 jsonschema = { version = "^4.19.0", extras = ["format"] }
+jsonpointer = "^2.4"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.4.0"

--- a/scripts/transformers/links_helper.py
+++ b/scripts/transformers/links_helper.py
@@ -1,0 +1,192 @@
+import re
+from typing import Optional
+from spec_types import OAPISchema
+
+FIND_VARIABLE_REGEX = r"/{(\w+)}$"
+
+
+def extract_path(input_path) -> str:
+    variable_match = re.search(FIND_VARIABLE_REGEX, input_path)
+    if variable_match:
+        return input_path[: variable_match.start()]
+
+    remaining_path = input_path.rsplit("/", 1)[0]
+    variable_before_match = re.search(FIND_VARIABLE_REGEX, remaining_path)
+    if variable_before_match:
+        return remaining_path + "/"
+
+    return input_path
+
+
+def handle_exp(
+    path: str,
+    request_schema: Optional[dict],
+    response_schema: Optional[dict],
+    response_header: dict,
+    action_parameters: list,
+):
+    # TODO if necessary, we could handle the other expressions here
+    # https://spec.openapis.org/oas/latest.html#runtime-expressions
+    if path.startswith("$request."):
+
+        def find_headers(field_name: str):
+            return is_action_parameter_present(field_name, "header", action_parameters)
+
+        return handle_source_exp(
+            path,
+            path.removeprefix("$request."),
+            request_schema,
+            find_headers,
+            action_parameters,
+        )
+    if path.startswith("$response."):
+
+        def find_headers(field_name: str):
+            return is_header_present(field_name, response_header)
+
+        return handle_source_exp(
+            path,
+            path.removeprefix("$response."),
+            response_schema,
+            find_headers,
+            action_parameters,
+        )
+    return None, None
+
+
+def handle_source_exp(
+    entire_path, path, body, find_headers, action_parameters
+) -> tuple[Optional[str], Optional[str]]:
+    if path.startswith("path."):
+        return get_rt_exp_path(
+            entire_path,
+            path.removeprefix("path"),
+            action_parameters,
+        )
+    if path.startswith("body"):
+        return get_rt_exp_body(
+            entire_path,
+            path.removeprefix("body"),
+            body,
+        )
+    if path.startswith("header."):
+        return get_rt_exp_header(
+            entire_path,
+            path.removeprefix("header"),
+            find_headers,
+        )
+    if path.startswith("query."):
+        return get_rt_exp_query(
+            entire_path,
+            path.removeprefix("query"),
+            action_parameters,
+        )
+    return None, None
+
+
+def get_rt_exp_path(
+    entire_exp: str,
+    field: str,
+    action_parameters: list,
+) -> tuple[str, Optional[str]]:
+    field_in_parameters = is_action_parameter_present(
+        field.removeprefix("."), "path", action_parameters
+    )
+    if field_in_parameters:
+        return field, entire_exp
+    return field, None
+
+
+def get_rt_exp_body(
+    entire_path,
+    json_pointer: str,
+    body: dict,
+) -> tuple[str, Optional[str]]:
+    field = get_field_from_json_pointer(json_pointer)
+
+    if body and check_field_in_schema(field.removeprefix("."), body):
+        new_path = build_path(entire_path, field.removeprefix("."))
+        return field, new_path
+    return field, None
+
+
+def get_rt_exp_header(
+    entire_exp: str,
+    field: str,
+    find_headers,
+) -> tuple[str, Optional[str]]:
+    field_in_parameters = find_headers(
+        field.removeprefix("."),
+    )
+    if field_in_parameters:
+        return field, entire_exp
+    return field, None
+
+
+def get_rt_exp_query(
+    entire_exp: str,
+    field: str,
+    action_parameters: list,
+) -> tuple[str, Optional[str]]:
+    field_in_parameters = is_action_parameter_present(
+        field.removeprefix("."), "query", action_parameters
+    )
+
+    if field_in_parameters:
+        return field, entire_exp
+    return field, None
+
+
+def is_action_parameter_present(
+    field_name: str, source: str, action_parameters: list
+) -> bool:
+    """
+    Check for a field in action_parameters with specific source
+    """
+    if action_parameters:
+        for obj in action_parameters:
+            if obj["name"] == field_name and obj["in"] == source:
+                return True
+
+    return False
+
+
+def get_field_from_json_pointer(json_pointer) -> str:
+    json_pointer = json_pointer.removeprefix("#/")
+    for i, char in enumerate(json_pointer):
+        if char in ["[", "/"]:
+            json_pointer = json_pointer[:i]
+            break
+    return json_pointer
+
+
+def check_field_in_schema(field: str, schema: dict) -> bool:
+    """
+    Check for a field in response schema
+    """
+    if schema:
+        try:
+            if field in schema["properties"]:
+                return True
+        except KeyError:
+            pass
+    return False
+
+
+def build_path(json_pointer: str, field: str) -> str:
+    if "#/" in json_pointer:
+        index = json_pointer.index("#/") + 2
+        return json_pointer[:index] + field
+    else:
+        return json_pointer
+
+
+def is_header_present(field_name: str, headers: dict) -> bool:
+    if headers:
+        if field_name in headers.values():
+            return True
+    return False
+
+
+def get_response_header(spec: OAPISchema, response: dict) -> dict:
+    return response.get("headers", {})

--- a/scripts/transformers/spec_check_links.py
+++ b/scripts/transformers/spec_check_links.py
@@ -1,8 +1,9 @@
 import argparse
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Optional
+from links_helper import get_response_header, handle_exp
 from spec_types import OAPISchema, SpecTranformer
 from urllib import parse
-
+import jsonpointer
 from transform_helpers import fetch_and_parse, load_yaml, save_external
 
 POSSIBLE_SOURCES = ["query", "header", "path", "body"]
@@ -38,14 +39,14 @@ class FixLinksTransformer(SpecTranformer):
                                         spec, response
                                     )
 
-                                    response_header = self._get_response_header(
+                                    response_header = get_response_header(
                                         spec, response
                                     )
 
                                     for key, link_path in link.get(
                                         "parameters", {}
                                     ).items():
-                                        field, result = self.handle_exp(
+                                        field, result = handle_exp(
                                             link_path,
                                             request_schema,
                                             response_schema,
@@ -94,145 +95,9 @@ class FixLinksTransformer(SpecTranformer):
 
         if "$ref" in schema:
             schema_path = schema["$ref"]
-            return self._resolve_schema_path(spec, schema_path)
+            return jsonpointer.resolve_pointer(spec, schema_path[1:])
         else:
             return schema
-
-    def _get_response_header(self, spec: OAPISchema, response: dict):
-        return response.get("headers", {})
-
-    def handle_exp(
-        self,
-        path: str,
-        request_schema: Optional[Dict],
-        response_schema: Optional[Dict],
-        response_header: dict,
-        action_parameters: list,
-    ):
-        # TODO if necessary, we could handle the other expressions here
-        # https://spec.openapis.org/oas/latest.html#runtime-expressions
-        if path.startswith("$request."):
-
-            def find_headers(field_name: str):
-                return self._is_action_parameter_present(
-                    field_name, "header", action_parameters
-                )
-
-            return self.handle_source_exp(
-                path,
-                path.removeprefix("$request."),
-                request_schema,
-                find_headers,
-                action_parameters,
-            )
-        elif path.startswith("$response."):
-
-            def find_headers(field_name: str):
-                return self._is_header_present(field_name, response_header)
-
-            return self.handle_source_exp(
-                path,
-                path.removeprefix("$response."),
-                response_schema,
-                find_headers,
-                action_parameters,
-            )
-        else:
-            return None, None
-
-    def handle_source_exp(
-        self, entire_path, path, body, find_headers, action_parameters
-    ):
-        if path.startswith("path."):
-            return self.get_rt_exp_path(
-                entire_path,
-                path.removeprefix("path"),
-                action_parameters,
-            )
-        if path.startswith("body"):
-            return self.get_rt_exp_body(
-                entire_path,
-                path.removeprefix("body"),
-                body,
-            )
-        if path.startswith("header."):
-            return self.get_rt_exp_header(
-                entire_path,
-                path.removeprefix("header"),
-                find_headers,
-            )
-        if path.startswith("query."):
-            return self.get_rt_exp_query(
-                entire_path,
-                path.removeprefix("query"),
-                action_parameters,
-            )
-
-    def get_rt_exp_path(
-        self,
-        entire_exp: str,
-        field: str,
-        action_parameters: list,
-    ) -> Tuple[str, Union[str, None]]:
-        field_in_parameters = self._is_action_parameter_present(
-            field.removeprefix("."), "path", action_parameters
-        )
-        if field_in_parameters:
-            return field, entire_exp
-        else:
-            return field, None
-
-    def get_rt_exp_body(
-        self,
-        entire_path,
-        json_pointer: str,
-        body: dict,
-    ) -> Tuple[str, Union[str, None]]:
-        # TODO: find a way to solve the json_pointer for field
-        # but that is not dependent of the data structure
-        field = self.get_field_from_json_pointer(json_pointer)
-
-        if body and self._check_field_in_schema(field.removeprefix("."), body):
-            new_path = self.build_path(entire_path, field.removeprefix("."))
-            return field, new_path
-        else:
-            return field, None
-
-    def build_path(self, json_pointer: str, field: str) -> str:
-        if "#/" in json_pointer:
-            index = json_pointer.index("#/") + 2
-            return json_pointer[:index] + field
-        else:
-            return json_pointer
-
-    def get_rt_exp_header(
-        self,
-        entire_exp: str,
-        field: str,
-        find_headers,
-    ) -> Tuple[str, Union[str, None]]:
-        field_in_parameters = find_headers(
-            field.removeprefix("."),
-        )
-        if field_in_parameters:
-            return field, entire_exp
-        else:
-            return field, None
-
-    def get_rt_exp_query(
-        self,
-        entire_exp: str,
-        field: str,
-        action_parameters: list,
-    ) -> Tuple[str, Union[str, None]]:
-        field_in_parameters = self._is_action_parameter_present(
-            field.removeprefix("."), "query", action_parameters
-        )
-
-        if field_in_parameters:
-            return field, entire_exp
-        else:
-            return field, None
 
     def search_for_all_except_current(
         self,
@@ -258,7 +123,7 @@ class FixLinksTransformer(SpecTranformer):
                 if new_exp == current:
                     continue
 
-                field, result = self.handle_exp(
+                field, result = handle_exp(
                     new_exp,
                     requestBody,
                     responseBody,
@@ -269,71 +134,6 @@ class FixLinksTransformer(SpecTranformer):
                     continue
                 else:
                     return result
-
-    def get_field_from_json_pointer(self, json_pointer):
-        json_pointer = json_pointer.removeprefix("#/")
-        for i, char in enumerate(json_pointer):
-            if char in ["[", "/"]:
-                json_pointer = json_pointer[:i]
-                break
-
-        return json_pointer
-
-    def _is_header_present(self, field_name: str, headers: dict) -> bool:
-        if headers:
-            if field_name in headers.values():
-                return True
-        return False
-
-    def _is_action_parameter_present(
-        self, field_name: str, source: str, action_parameters: list
-    ) -> bool:
-        """
-        Check for a field in action_parameters with specific source
-        """
-        if action_parameters:
-            for obj in action_parameters:
-                if obj["name"] == field_name and obj["in"] == source:
-                    return True
-        return False
-
-    def _check_field_in_schema(self, field: str, schema: Dict) -> bool:
-        """
-        Check for a field in response schema
-        """
-        if schema:
-            if field in schema.get("properties", {}):
-                return True
-        return False
-
-    def _resolve_schema_path(self, spec: Dict, path: str) -> Optional[Dict]:
-        """
-        Resolves the path to a schema.
-
-        Args:
-            spec: the openapi definition
-            path: the path of the schema defined in $ref.
-            Example: '#/components/schemas/<name>'
-
-        Returns:
-            The schema definition dictionary, or None if not found.
-        """
-        if not path:
-            return None
-
-        components = path.split("/")
-
-        if components[0] == "#":
-            components = components[1:]
-
-        current_dict = spec
-        for component in components:
-            if component in current_dict:
-                current_dict = current_dict[component]
-            else:
-                return None
-
-        return current_dict
 
 
 if __name__ == "__main__":

--- a/scripts/transformers/spec_create_links.py
+++ b/scripts/transformers/spec_create_links.py
@@ -1,6 +1,11 @@
-from typing import List, Optional, Tuple
+import re
+from typing import Optional
+from links_helper import extract_path, handle_exp
 from spec_types import OAPISchema, SpecTranformer
+import jsonpointer
 
+POSSIBLE_PARENTS = ["request", "response"]
+POSSIBLE_SOURCES = ["query", "header", "path", "body"]
 METHODS_ALIAS = {
     "get": "get",
     "post": "create",
@@ -8,55 +13,275 @@ METHODS_ALIAS = {
     "put": "replace",
     "delete": "delete",
 }
-POSSIBLE_PARENTS = ["request", "response"]
-POSSIBLE_SOURCES = ["query", "header", "path", "body"]
 
 
 class CreateLinks(SpecTranformer):
     """Create links"""
 
     def transform(self, spec: OAPISchema) -> OAPISchema:
-        self._generate_links(spec)
+        all_paths = spec.get("paths", {})
+
+        tree_root, level_paths, _ = build_tree(all_paths)
+        related_paths = self.get_commom_parent_paths(level_paths)
+        generated_links = self.generate_all_links(spec, related_paths, tree_root)
+
+        for path, operations in spec.get("paths", {}).items():
+            link = generated_links.get(path, {})
+            if link:
+                self.populate_action_links(spec, operations, link)
+
         return spec
 
-    def _generate_links(self, spec: OAPISchema) -> None:
-        all_paths = list(spec.get("paths", {}).keys())
-        path_prefixes = self.get_path_prefixes(all_paths)
+    def generate_all_links(self, spec, related_paths, tree_root) -> dict:
+        generated_links = {}
+        for level in related_paths.keys():
+            for element in related_paths[level]:
+                links_for_prefix = self.generate_links(spec, element, tree_root)
+                generated_links[element["path"]] = links_for_prefix
+        return generated_links
 
-        pre_links = self.generate_pre_links(spec, all_paths, path_prefixes)
+    def generate_links(self, spec, prefix, tree_root) -> dict:
+        new_links = {}
+        for path, operations in spec.get("paths", {}).items():
+            if (
+                path.startswith(prefix["prefix"])
+                and find_path_level(tree_root, path) == prefix["level"]
+            ):
+                for method, operation in operations.items():
+                    try:
+                        operationId = operation["operationId"]
+                        required_parameters = self.get_required_parameters(
+                            spec, operation
+                        )
+                        requestBody = operation.get("requestBody", None)
 
-        for path, methods in spec.get("paths", {}).items():
-            start, prefix = self.path_has_prefix(path, pre_links)
-            if start:
-                self.get_links_for_path(spec, methods, pre_links[prefix])
+                        if required_parameters:
+                            key = self.generate_link_name(method, path)
+                            new_obj = {
+                                "operationId": operationId,
+                                "description": operation.get("description", {}),
+                                "parameters": required_parameters,
+                            }
+                            new_links[key] = new_obj
 
-    def generate_pre_links(
-        self, spec: OAPISchema, all_paths: List, prefixes: List
-    ) -> dict:
-        pre_links = {}
-        for prefix in prefixes:
-            links_for_prefix = self.get_pre_links(spec, all_paths, prefix)
-            pre_links[prefix] = links_for_prefix
+                        if "get" in operations and "post" in operations:
+                            continue
+                        if requestBody:
+                            new_link_name, new_link = self.generate_update_link(
+                                spec,
+                                prefix,
+                                path,
+                                operationId,
+                                operation,
+                                required_parameters,
+                            )
 
-        return pre_links
+                            if new_link_name and new_link:
+                                new_links[new_link_name] = new_link
+                    except KeyError:
+                        pass
+        return new_links
 
-    def get_links_for_path(self, spec: OAPISchema, methods: dict, pre_links: dict):
-        for method, action in methods.items():
+    def generate_update_link(
+        self,
+        spec,
+        prefix,
+        path,
+        operationId,
+        operation,
+        required_parameters,
+    ) -> tuple[Optional[str], Optional[dict]]:
+        (
+            is_valid,
+            property_name,
+        ) = self.validate_request_body_to_update(
+            spec, operation.get("requestBody", {}), prefix, path
+        )
+        if is_valid and property_name:
+            key = self.generate_update_link_name(property_name)
+            new_obj = {
+                "operationId": operationId,
+                "description": operation.get("description", {}),
+                "parameters": required_parameters,
+                "x-mgc-hidden": "true",
+            }
+            return key, new_obj
+        return None, None
+
+    def get_commom_parent_paths(self, level_nodes) -> dict:
+        result_set: dict = {}
+        for level, paths in level_nodes.items():
+            result_set[level] = []
+            for path in paths:
+                result = extract_path(path)
+                obj = {"level": level, "prefix": result, "path": path}
+                result_set.setdefault(level, []).append(obj)
+
+        return result_set
+
+    def get_required_parameters(self, spec, operation: dict) -> list:
+        """
+        Build the parameters for the link
+        """
+        required_parameters = []
+        try:
+            params = operation.get("parameters", {})
+
+            for param in params:
+                if "$ref" in param:
+                    schema = jsonpointer.resolve_pointer(spec, param["$ref"][1:])
+                    if schema.get("in") == "path":
+                        required_parameters.append(schema)
+
+                else:
+                    for parameter in operation.get("parameters", []):
+                        if parameter.get("in") == "path":
+                            required_parameters.append(parameter)
+
+        except KeyError:
+            pass
+
+        return required_parameters
+
+    def generate_link_name(self, method: str, path: str) -> str:
+        if method.lower() == "post":
+            id_index = path.rfind("id}/")
+            if id_index != -1:
+                action = path[id_index + len("id}/") :]
+                return action.split("/")[0].lower()
+
+        path_parts = path.strip("/").split("/")
+        last_part = path_parts[-1]
+        if "{" in last_part and "}" in last_part:
+            path_parts.pop()
+            last_part = path_parts[-1]
+
+        link_name = METHODS_ALIAS.get(method.lower(), "default")
+
+        return link_name
+
+    def validate_request_body_to_update(
+        self, spec: OAPISchema, requestBody: dict, prefix: str, given_path: str
+    ) -> tuple[bool, Optional[str]]:
+        if not requestBody:
+            return False, None
+        has, path_prefix = self.check_path_variable(given_path)
+        if not has:
+            return False, None
+
+        response_schema: Optional[dict] = {}
+        for path, value in spec.get("paths", {}).items():
+            if path.startswith(path_prefix) and path.endswith("}"):
+                for method, operation in value.items():
+                    if method == "get":
+                        try:
+                            success_response = self.find_first_success_response(
+                                operation.get("responses", {})
+                            )
+
+                            if not success_response:
+                                return False, None
+
+                            response_schema = self._get_content_app_json_schema(
+                                spec, success_response
+                            )
+
+                        except KeyError:
+                            pass
+        if response_schema:
+            props_list = list(response_schema.get("properties", {}).keys())
+            properties = response_schema.get("properties", {})
+        if props_list:
+            try:
+                schema = self._get_content_app_json_schema(spec, requestBody)
+                if not schema:
+                    return False, None
+                if self.is_valid_schema(schema):
+                    name = list(schema["properties"].keys())
+                    if (
+                        name[0] in props_list
+                        and properties[name[0]]["type"] == "string"
+                    ):
+                        return True, name[0]
+            except KeyError:
+                pass
+        return False, None
+
+    def find_first_success_response(self, operations) -> Optional[dict]:
+        for status, operation in operations.items():
+            if status.startswith("2"):
+                return operation
+        return None
+
+    def is_valid_schema(self, schema) -> bool:
+        """
+        We will create update links only for
+        the methods that has a requestBody
+        with only ONE parameter
+        and that parameter is returned on the GET
+        for the same path
+        """
+        return len(schema.get("properties", {}).keys()) == 1
+
+    def _get_content_app_json_schema(
+        self, spec: OAPISchema, sourceDict
+    ) -> Optional[dict]:
+        """
+        Return the path of the schema refered in response content
+        """
+        schema = {}
+        try:
+            schema = sourceDict["content"]["application/json"]["schema"]
+        except KeyError:
+            return None
+
+        if "$ref" in schema:
+            schema_path = schema["$ref"]
+            return jsonpointer.resolve_pointer(spec, schema_path[1:])
+        else:
+            return schema
+
+    def check_path_variable(self, path: str) -> tuple[bool, Optional[str]]:
+        match = re.search(r"(.*)/\{[^/]+\}$", path)
+        if match:
+            return False, match.group(1)
+        else:
+            remaining_path = path.rsplit("/", 1)[0]
+
+            remaining_match = re.search(r"(.*)/\{[^/]+\}$", remaining_path)
+            if remaining_match:
+                return True, remaining_path
+
+        return False, None
+
+    def generate_update_link_name(self, property_name: str) -> str:
+        name = "update/" + property_name
+        return name
+
+    def populate_action_links(
+        self, spec: OAPISchema, operations: dict, pre_links: dict
+    ):
+        for method, operation in operations.items():
             if method == "delete":
                 continue
-            action_parameters = action.get("parameters", [])
+            action_parameters = self.resolve_params(spec, operation)
             request_schema = self._get_content_app_json_schema(
-                spec, action.get("requestBody", {})
+                spec, operation.get("requestBody", {})
             )
-            # Check how get the response_schema withou going through responses
-            action_response = action.get("responses", {})
-            status = action_response.get("200", {})
-            response_schema = self._get_content_app_json_schema(spec, status)
-            response_header = self._get_response_header(spec, status)
+            success_response = self.find_first_success_response(
+                operation.get("responses", {})
+            )
+
+            if not success_response:
+                return
+            response_schema = self._get_content_app_json_schema(spec, success_response)
+            response_header = self.get_response_header(success_response)
             generated_links = {}
-            for operation, value in pre_links.items():
+            for link_name, value in pre_links.items():
                 params = {}
-                for param in value.get("parameters", {}):
+                if value.get("operationId") == operation.get("operationId"):
+                    continue
+                for param in value["parameters"]:
                     result = self.search_for_path(
                         param["name"],
                         response_schema,
@@ -72,14 +297,38 @@ class CreateLinks(SpecTranformer):
                         "description": value["description"],
                         "parameters": params,
                     }
-                    generated_links[operation] = new_link
+                    if value.get("x-mgc-hidden", {}) == "true":
+                        new_link.setdefault("x-mgc-hidden", True)
+                    generated_links[link_name] = new_link
             if generated_links:
                 try:
-                    for status in action["responses"].keys():
+                    for status in operation["responses"].keys():
                         if status == "default" or status.startswith("2"):
-                            action["responses"][status]["links"] = generated_links
+                            operation["responses"][status]["links"] = generated_links
                 except KeyError:
                     pass
+
+    def resolve_params(self, spec, operation) -> list:
+        """
+        Build the parameters for the link
+        """
+        required_parameters = []
+        try:
+            params = operation.get("parameters", {})
+            for param in params:
+                if "$ref" in param:
+                    schema_path = param["$ref"]
+                    schema = jsonpointer.resolve_pointer(spec, schema_path[1:])
+                    required_parameters.append(schema)
+                else:
+                    required_parameters.append(param)
+
+        except KeyError:
+            pass
+        return required_parameters
+
+    def get_response_header(self, response: dict) -> dict:
+        return response.get("headers", {})
 
     def search_for_path(
         self,
@@ -97,7 +346,7 @@ class CreateLinks(SpecTranformer):
                     new_exp = "$" + parent + "." + s + "#/" + field_name
                 else:
                     new_exp = "$" + parent + "." + s + field_name
-                field, result = self.handle_exp(
+                _, result = handle_exp(
                     new_exp,
                     request_schema,
                     response_schema,
@@ -108,376 +357,65 @@ class CreateLinks(SpecTranformer):
                     continue
                 else:
                     return result
-        pass
 
-    def get_path_prefixes(self, paths: list):
-        """
-        Receives a list of all the paths from the openapi
-        Return list of commom prefixes
-        Example:
-        receives ['<version>/<resource>/<variable>',
-            '<version>/<resource>/<variable>/<action>]
-        returns ['<version>/<resource>']
 
-        With this list, we can map all the possible links to a specific resource
-        and use it to define the links for each action
-        """
-        result_set = set()
-        for path in paths:
-            first_slash = path.find("/")
-            if first_slash != -1:
-                version = path.find("/", first_slash + 1)
-                if version != -1:
-                    resource = path.find("/", version + 1)
-                    if resource != -1:
-                        result_set.add(path[:resource])
-                    else:
-                        result_set.add(path[:resource])
+class TreeNode:
+    def __init__(self, name):
+        self.name = name
+        self.children = {}
+        self.paths = []
 
-        prefixes = list(result_set)
-        return prefixes
 
-    def get_pre_links(self, spec: OAPISchema, all_paths: List, prefix: str) -> dict:
-        new_links = {}
-        for path, value in spec.get("paths", {}).items():
-            if path.startswith(prefix):
-                for method, body in value.items():
-                    try:
-                        operationId = body["operationId"]
-                        required_parameters = self.get_required_parameters(body)
-                        # Confirm: if there is no parameters so there is no link?
-                        """
-                        here we must check for the requestBody
-                        to confirm it exists
-                        if yes, we must check for the get
-                        to confirm if it return the the same data
-                        if yes, create a update/<property_name>
-                        """
-                        if required_parameters:
-                            key = self.generate_link_name(method, path)
-                            new_obj = {
-                                "operationId": operationId,
-                                "description": body.get("description", {}),
-                                "parameters": required_parameters,
-                            }
-                            new_links[key] = new_obj
-
-                        requestBody = body.get("requestBody", None)
-                        if requestBody:
-                            (
-                                is_valid,
-                                property_name,
-                            ) = self.validate_request_body_to_update(
-                                spec, requestBody, prefix
-                            )
-                            if is_valid:
-                                key = self.generate_update_link_name(property_name)
-                                new_obj = {
-                                    "operationId": operationId,
-                                    "description": body.get("description", {}),
-                                    "parameters": required_parameters,
-                                }
-                                new_links[key] = new_obj
-
-                    except KeyError:
-                        pass
-        return new_links
-
-    def generate_update_link_name(self, property_name: str) -> str:
-        name = "update/" + property_name
-        return name
-
-    def get_required_parameters(self, body: dict):
-        """
-        Build the parameters for the link
-        """
-        required_parameters = [
-            parameter
-            for parameter in body.get("parameters", [])
-            if parameter.get("required", True)
-        ]
-
-        return required_parameters
-
-    def generate_link_name(self, method: str, path: str) -> str:
-        """
-        Note: This is very likeli to broke if
-        there is a different pattern. Check it later
-        Returns the name of the link
-        Using this to avoid the error of overwriting
-        every link with post method
-        """
-        if method.lower() == "post":
-            id_index = path.rfind("{id}/")
-            if id_index != -1:
-                action = path[id_index + len("{id}/") :]
-                return action.lower()
-        link_name = METHODS_ALIAS.get(method, "default")
-        return link_name
-
-    def validate_request_body_to_update(
-        self, spec: OAPISchema, requestBody: dict, prefix: str
-    ):
-        response_schema = {}
-        for path, value in spec.get("paths", {}).items():
-            if path.startswith(prefix) and path.endswith("}"):
-                for method, body in value.items():
-                    if method == "get":
-                        try:
-                            # TODO confirm is must check only in 200 status
-                            response_schema = self._get_content_app_json_schema(
-                                spec, body["responses"]["200"]
-                            )
-                        except KeyError:
-                            pass
-
-        props = list(response_schema.get("properties", {}).keys())
-
-        if props:
-            try:
-                schema = self._get_content_app_json_schema(spec, requestBody)
-                if self.is_valid_schema(schema):
-                    name = list(schema["properties"].keys())
-                    if name[0] in props:
-                        return True, name[0]
-            except KeyError:
-                pass
-
-        return False, None
-
-    def is_valid_schema(self, schema):
-        """
-        We will create update links only for
-        the methods that has a requestBody
-        with only ONE parameter
-        and that parameter is returned on the GET
-        for the same path
-        """
-        return len(schema.get("properties", {}).keys()) == 1
-
-    def _get_content_app_json_schema(self, spec: OAPISchema, sourceDict):
-        """
-        Return the path of the schema refered in response content
-        """
-        schema = {}
-        try:
-            schema = sourceDict["content"]["application/json"]["schema"]
-        except KeyError:
-            return None
-
-        if "$ref" in schema:
-            schema_path = schema["$ref"]
-            return self._resolve_schema_path(spec, schema_path)
-        else:
-            return schema
-
-    def path_has_prefix(self, input_string: str, prefix_dict: dict) -> Tuple[bool, str]:
-        for prefix in prefix_dict.keys():
-            if input_string.startswith(prefix):
-                return True, prefix
-        return False, prefix
-
-    def _get_response_header(self, spec: OAPISchema, response: dict):
-        return response.get("headers", {})
-
+def build_tree(
+    paths,
+) -> tuple[TreeNode, dict[int, list[str]], dict[int, list[tuple[TreeNode, str]]]]:
     """
-    TODO to validate the created link path i used some functions
-    from spec_check_links.py. If the approach is okay
-    i can it all to another file
+    It receives a list of paths and build a tree from its components
+    Each path is parsed by / and each result part becomes a node
     """
+    root = TreeNode("/")
+    level_paths: dict = {}  # Dictionary to store paths at each level
+    level_nodes: dict[int, list[tuple[TreeNode, str]]] = {0: [(root, "")]}
 
-    def handle_exp(
-        self,
-        path: str,
-        request_schema: Optional[dict],
-        response_schema: Optional[dict],
-        response_header: dict,
-        action_parameters: list,
-    ):
-        # TODO if necessary, we could handle the other expressions here
-        # https://spec.openapis.org/oas/latest.html#runtime-expressions
-        if path.startswith("$request."):
+    for path in paths:
+        current_node = root
+        components = path.split("/")[1:]
 
-            def find_headers(field_name: str):
-                return self._is_action_parameter_present(
-                    field_name, "header", action_parameters
-                )
+        for level, component in enumerate(components, start=1):
+            if component not in current_node.children:
+                new_node = TreeNode(component)
+                current_node.children[component] = new_node
 
-            return self.handle_source_exp(
-                path,
-                path.removeprefix("$request."),
-                request_schema,
-                find_headers,
-                action_parameters,
-            )
-        elif path.startswith("$response."):
+                level_paths.setdefault(level, []).append(path)
+                level_nodes.setdefault(level, []).append((new_node, path))
 
-            def find_headers(field_name: str):
-                return self._is_header_present(field_name, response_header)
-
-            return self.handle_source_exp(
-                path,
-                path.removeprefix("$response."),
-                response_schema,
-                find_headers,
-                action_parameters,
-            )
-        else:
-            return None, None
-
-    def handle_source_exp(
-        self, entire_path, path, body, find_headers, action_parameters
-    ):
-        if path.startswith("path."):
-            return self.get_rt_exp_path(
-                entire_path,
-                path.removeprefix("path"),
-                action_parameters,
-            )
-        if path.startswith("body"):
-            return self.get_rt_exp_body(
-                entire_path,
-                path.removeprefix("body"),
-                body,
-            )
-        if path.startswith("header."):
-            return self.get_rt_exp_header(
-                entire_path,
-                path.removeprefix("header"),
-                find_headers,
-            )
-        if path.startswith("query."):
-            return self.get_rt_exp_query(
-                entire_path,
-                path.removeprefix("query"),
-                action_parameters,
-            )
-
-    def get_rt_exp_path(
-        self,
-        entire_exp: str,
-        field: str,
-        action_parameters: list,
-    ):
-        field_in_parameters = self._is_action_parameter_present(
-            field.removeprefix("."), "path", action_parameters
-        )
-        if field_in_parameters:
-            return field, entire_exp
-        else:
-            return field, None
-
-    def get_rt_exp_body(
-        self,
-        entire_path,
-        json_pointer: str,
-        body: dict,
-    ):
-        # TODO: find a way to solve the json_pointer for field
-        # but that is not dependent of the data structure
-        field = self.get_field_from_json_pointer(json_pointer)
-
-        if body and self._check_field_in_schema(field.removeprefix("."), body):
-            new_path = self.build_path(entire_path, field.removeprefix("."))
-            return field, new_path
-        else:
-            return field, None
-
-    def get_rt_exp_header(
-        self,
-        entire_exp: str,
-        field: str,
-        find_headers,
-    ):
-        field_in_parameters = find_headers(
-            field.removeprefix("."),
-        )
-        if field_in_parameters:
-            return field, entire_exp
-        else:
-            return field, None
-
-    def get_rt_exp_query(
-        self,
-        entire_exp: str,
-        field: str,
-        action_parameters: list,
-    ):
-        field_in_parameters = self._is_action_parameter_present(
-            field.removeprefix("."), "query", action_parameters
-        )
-
-        if field_in_parameters:
-            return field, entire_exp
-        else:
-            return field, None
-
-    def _is_action_parameter_present(
-        self, field_name: str, source: str, action_parameters: list
-    ) -> bool:
-        """
-        Check for a field in action_parameters with specific source
-        """
-        if action_parameters:
-            for obj in action_parameters:
-                if obj["name"] == field_name and obj["in"] == source:
-                    return True
-        return False
-
-    def get_field_from_json_pointer(self, json_pointer):
-        json_pointer = json_pointer.removeprefix("#/")
-        for i, char in enumerate(json_pointer):
-            if char in ["[", "/"]:
-                json_pointer = json_pointer[:i]
-                break
-
-        return json_pointer
-
-    def _check_field_in_schema(self, field: str, schema: dict) -> bool:
-        """
-        Check for a field in response schema
-        """
-        if schema:
-            if field in schema.get("properties", {}):
-                return True
-        return False
-
-    def build_path(self, json_pointer: str, field: str) -> str:
-        if "#/" in json_pointer:
-            index = json_pointer.index("#/") + 2
-            return json_pointer[:index] + field
-        else:
-            return json_pointer
-
-    def _is_header_present(self, field_name: str, headers: dict) -> bool:
-        if headers:
-            if field_name in headers.values():
-                return True
-        return False
-
-    def _resolve_schema_path(self, spec: OAPISchema, path: str):
-        # TODO define a proper solver for the schema path
-        """
-        Resolves the path to a schema.
-        Args:
-            spec: the openapi definition
-            path: the path of the schema defined in $ref.
-            Example: '#/components/schemas/<name>'
-        Returns:
-            The schema definition dictionary, or None if not found.
-        """
-        if not path:
-            return None
-
-        components = path.split("/")
-
-        if components[0] == "#":
-            components = components[1:]
-
-        current_dict = spec
-        for component in components:
-            if component in current_dict:
-                current_dict = current_dict[component]
             else:
-                return None
-        return current_dict
+                current_node.paths.append(path)
+
+            current_node = current_node.children[component]
+
+    return root, level_paths, level_nodes
+
+
+def find_path_level(root, path) -> int:
+    current_node = root
+    components = path.split("/")[1:]
+
+    for level, component in enumerate(components, start=1):
+        if component in current_node.children:
+            current_node = current_node.children[component]
+        else:
+            break
+
+    return level
+
+
+def print_tree(node, indent=0) -> None:
+    """
+    Helper function to visualize the generated tree
+    You can call it by passing the root node returned
+    by build_tree
+    """
+    print("  " * indent + node.name)
+    for child in node.children.values():
+        print_tree(child, indent + 1)


### PR DESCRIPTION
## Description
Some changes that were applyed:
- [x] Resolving $refs in action parameters
- [x] Fixing update links to wrong resources
- [x] Better link naming
- [x] Using the jsonPointer resolver to resolve referenced schemas
- [x] Using tree structure to get related paths when building links
- [x] Easier debugging with the func to print the tree to use as reference

## How to test

- Get an openapi.yaml
- Run the `scripts/transformer/transform.py` on it and check the result file
- To make it easier to analyze which paths are related, call the print_tree function in `spec_create_links.py` to see the tree structure of the paths
