### PR TITLE
fix(object-storage): remove url encoding from list request

### DIFF
--- a/mgc/sdk/static/object_storage/common/list.go
+++ b/mgc/sdk/static/object_storage/common/list.go
@@ -170,7 +170,6 @@ func buildListRequestURL(cfg Config, bucketURI mgcSchemaPkg.URI) (*url.URL, erro
 		}
 		q.Set("prefix", path)
 	}
-	q.Set("encoding-type", "url")
 	u.RawQuery = q.Encode()
 	return u, nil
 }


### PR DESCRIPTION
## Description

Setting the encoding-type as url was making it so that filenames with spaces in them would show up `%20`. This PR removes that.

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Upload a file containing spaces in its name using `go run . object-storage objects upload`, then try listing objects with `objects list`. Also try `objects upload-dir`, `objects download-all` and `objects download` without a destination to see how the spaces in the filename are handled. At no point should there be any names containing `%20` where a space should be.