### PR TITLE
feat(object-storage): add `objects head` command

### DIFF
--- a/mgc/sdk/static/object_storage/common/const.go
+++ b/mgc/sdk/static/object_storage/common/const.go
@@ -47,4 +47,8 @@ const (
 	MinBatchSize = 1
 
 	delimiter = "/"
+
+	HeadContentLengthBase = 10
+
+	HeadContentLengthBitSize = 64
 )

--- a/mgc/sdk/static/object_storage/objects/group.go
+++ b/mgc/sdk/static/object_storage/objects/group.go
@@ -18,6 +18,7 @@ var GetGroup = utils.NewLazyLoader[core.Grouper](func() core.Grouper {
 				getDeleteAll(),   // object-storage objects delete-all
 				getDownload(),    // object-storage objects download
 				getDownloadAll(), // object-storage objects download-all
+				getHead(),        // object-storage objects head
 				getList(),        // object-storage objects list
 				getUpload(),      // object-storage objects upload
 				getUploadDir(),   // object-storage objects upload-dir

--- a/mgc/sdk/static/object_storage/objects/head.go
+++ b/mgc/sdk/static/object_storage/objects/head.go
@@ -1,0 +1,111 @@
+package objects
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"magalu.cloud/core"
+	"magalu.cloud/core/progress_report"
+	mgcSchemaPkg "magalu.cloud/core/schema"
+	"magalu.cloud/core/utils"
+	"magalu.cloud/sdk/static/object_storage/common"
+)
+
+type headObjectParams struct {
+	Destination mgcSchemaPkg.URI `json:"dst" jsonschema:"description=Path of the object to be get metadata from,example=s3://bucket1/file.txt" mgc:"positional"`
+}
+
+type headObjectRequestResponse struct {
+	AcceptRanges  string
+	LastModified  string
+	ContentLength int64
+	ETag          string
+	ContentType   string
+}
+
+var getHead = utils.NewLazyLoader[core.Executor](func() core.Executor {
+	return core.NewStaticExecute(
+		core.DescriptorSpec{
+			Name:        "head",
+			Description: "Get object metadata",
+		},
+		headObject,
+	)
+})
+
+func newHeadRequest(ctx context.Context, cfg common.Config, dst mgcSchemaPkg.URI) (*http.Request, error) {
+	host, err := common.BuildBucketHostWithPath(cfg, common.NewBucketNameFromURI(dst), dst.Path())
+	if err != nil {
+		return nil, core.UsageError{Err: err}
+	}
+	return http.NewRequestWithContext(ctx, http.MethodHead, string(host), nil)
+}
+
+func headFile(ctx context.Context, cfg common.Config, dst mgcSchemaPkg.URI) (*http.Response, error) {
+	req, err := newHeadRequest(ctx, cfg, dst)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := common.SendRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = common.ExtractErr(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func parseContentLength(contentLenght string) (int64, error) {
+	value, err := strconv.ParseInt(contentLenght, common.HeadContentLengthBase, common.HeadContentLengthBitSize)
+	if err != nil {
+		return 0, err
+	}
+	return value, nil
+}
+
+func getMetadataFromResponse(resp *http.Response) (headObjectRequestResponse, error) {
+	contentLength, err := parseContentLength(resp.Header.Get("Content-Length"))
+	if err != nil {
+		return headObjectRequestResponse{}, err
+	}
+
+	metadata := headObjectRequestResponse{
+		AcceptRanges:  resp.Header.Get("Accept-Ranges"),
+		LastModified:  resp.Header.Get("Last-Modified"),
+		ContentLength: contentLength,
+		ETag:          resp.Header.Get("ETag"),
+		ContentType:   resp.Header.Get("Content-Type"),
+	}
+
+	return metadata, nil
+}
+
+func headObject(ctx context.Context, p headObjectParams, cfg common.Config) (result core.Value, err error) {
+	reportProgress := progress_report.FromContext(ctx)
+	reportMsg := "Getting metadata for " + p.Destination.String()
+	progress := uint64(0)
+	total := uint64(1)
+
+	reportProgress(reportMsg, progress, progress, progress_report.UnitsNone, nil)
+
+	resp, err := headFile(ctx, cfg, p.Destination)
+	if err != nil {
+		reportProgress(reportMsg, progress, progress, progress_report.UnitsNone, err)
+		return nil, err
+	}
+
+	reportProgress(reportMsg, total, total, progress_report.UnitsNone, progress_report.ErrorProgressDone)
+
+	result, err = getMetadataFromResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -18373,6 +18373,79 @@
        },
        "type": "object"
       },
+      "description": "Get object metadata",
+      "isInternal": false,
+      "name": "head",
+      "parameters": {
+       "properties": {
+        "dst": {
+         "description": "Path of the object to be get metadata from",
+         "example": "s3://bucket1/file.txt",
+         "format": "uri",
+         "type": "string"
+        }
+       },
+       "required": [
+        "dst"
+       ],
+       "type": "object"
+      },
+      "result": {
+       "anyOf": [
+        {
+         "nullable": true,
+         "type": "null"
+        },
+        {
+         "type": "boolean"
+        },
+        {
+         "type": "string"
+        },
+        {
+         "type": "number"
+        },
+        {
+         "type": "integer"
+        },
+        {
+         "type": "array"
+        },
+        {
+         "additionalProperties": true,
+         "type": "object"
+        }
+       ],
+       "nullable": true
+      },
+      "version": ""
+     },
+     {
+      "configs": {
+       "properties": {
+        "region": {
+         "default": "br-ne-1",
+         "description": "Region to reach the service",
+         "enum": [
+          "br-ne-1",
+          "br-se-1"
+         ],
+         "type": "string"
+        },
+        "serverUrl": {
+         "description": "Manually specify the server to use",
+         "format": "uri",
+         "type": "string"
+        },
+        "workers": {
+         "default": 5,
+         "description": "Number of routines that spawn to do parallel operations within object_storage",
+         "minimum": 1,
+         "type": "integer"
+        }
+       },
+       "type": "object"
+      },
       "description": "List all objects from a bucket",
       "isInternal": false,
       "name": "list",

--- a/script-qa/cli-help/object-storage/objects/head/help.txt
+++ b/script-qa/cli-help/object-storage/objects/head/help.txt
@@ -1,0 +1,18 @@
+Get object metadata
+
+Usage:
+  ./cli object-storage objects head [dst] [flags]
+
+Examples:
+  ./cli object-storage objects head --dst="s3://bucket1/file.txt"
+
+Flags:
+      --dst uri   Path of the object to be get metadata from (required)
+  -h, --help      help for head
+
+Global Flags:
+      --cli.show-cli-globals   Show all CLI global flags on usage text
+      --region enum            Region to reach the service (one of "br-ne-1" or "br-se-1") (default "br-ne-1")
+      --server-url uri         Manually specify the server to use
+      --workers integer        Number of routines that spawn to do parallel operations within object_storage (min: 1) (default 5)
+

--- a/script-qa/cli-help/object-storage/objects/help.txt
+++ b/script-qa/cli-help/object-storage/objects/help.txt
@@ -10,6 +10,7 @@ Commands:
   delete-all   Delete all objects from a bucket
   download     Download an object from a bucket
   download-all Download all objects from a bucket
+  head         Get object metadata
   list         List all objects from a bucket
   upload       Upload a file to a bucket
   upload-dir   Upload a directory to a bucket


### PR DESCRIPTION
## Description

This PR adds a new command to retrieve the metadata of an object by providing its URI.

## Related Issues

- #764

### Pull request checklist

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

Upload any object using `go run . object-storage objects upload` or `upload-dir`, then run `go run . object-storage objects head` on the uploaded object URI and check that the metadata is accurate.