### PR TITLE
fix(object-storage): display `download-all` errors

### DIFF
--- a/mgc/sdk/static/object_storage/objects/download_all.go
+++ b/mgc/sdk/static/object_storage/objects/download_all.go
@@ -58,20 +58,20 @@ func createObjectDownloadProcessor(cfg common.Config, params downloadAllObjectsP
 
 		if dirEntry.Err() != nil {
 			err = &common.ObjectError{Url: mgcSchemaPkg.URI(objURI), Err: dirEntry.Err()}
-			return err, pipeline.ProcessSkip
+			return err, pipeline.ProcessOutput
 		}
 
 		_, ok := dirEntry.DirEntry().(*common.BucketContent)
 		if !ok {
 			err = &common.ObjectError{Url: mgcSchemaPkg.URI(objURI), Err: fmt.Errorf("expected object, got directory")}
-			return err, pipeline.ProcessSkip
+			return err, pipeline.ProcessOutput
 		}
 
 		downloadAllLogger().Infow("Downloading object", "uri", objURI)
 		err = downloadSingleFile(ctx, cfg, objURI, params.Destination.Join(dirEntry.Path()))
 		if err != nil {
 			err = &common.ObjectError{Url: mgcSchemaPkg.URI(objURI), Err: err}
-			return err, pipeline.ProcessSkip
+			return err, pipeline.ProcessOutput
 		}
 
 		return nil, pipeline.ProcessOutput


### PR DESCRIPTION
## Description

During the `objects download-all` operation, we were not properly returning the errors that could occur during parallel processing. This PR fixes that.

## Related Issues

- #750

### Pull request checklist

<!-- Before submitting the PR, please address each item -->

- [ ] **Tests**: This PR includes tests for covering the features or bug fixes (if applicable).
- [ ] **Docs**: This PR updates/creates the necessary documentation.
- [x] **CI**: Make sure your Pull Request passes all CI checks. If not, clarify the motif behind that and the action plan to solve it (may reference a ticket)

## How to test it

You can force errors during the `go run . object-storage objects download-all` operation, for example, by going to line 71 of `mgc/sdk/static/object_storage/objects/download_all.go` and replacing `params.Destination.Join(dirEntry.Path())` with `params.Destination`. This should make the operation return an error for each object downloaded. After that, revert the changes to the same line and the downloads should conclude successfully without any errors.
