### PR TITLE
feat(cli): add debug flag

### DIFF
--- a/mgc/cli/cmd/log_debug.go
+++ b/mgc/cli/cmd/log_debug.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const logDebugFlag = "debug"
+const logDebugDef = "debug+:*"
+
+func addLogDebugFlag(cmd *cobra.Command) {
+	cmd.Root().PersistentFlags().BoolP(
+		logDebugFlag,
+		"d",
+		false,
+		`Display detailed log information at the debug level`,
+	)
+}
+
+func getLogDebugFlag(cmd *cobra.Command) string {
+	if result, ok := cmd.Root().PersistentFlags().GetBool(logDebugFlag); ok == nil {
+		if result {
+			return logDebugDef
+		}
+	}
+
+	return ""
+}

--- a/mgc/cli/cmd/log_filter.go
+++ b/mgc/cli/cmd/log_filter.go
@@ -21,6 +21,11 @@ See more details about the filter syntax at https://github.com/moul/zapfilter`,
 }
 
 func getLogFilterFlag(cmd *cobra.Command) string {
+	// debug take precedence over cli.logs
+	dbgFlagResult := getLogDebugFlag(cmd)
+	if dbgFlagResult != "" {
+		return dbgFlagResult
+	}
 	return cmd.Root().PersistentFlags().Lookup(logFilterFlag).Value.String()
 }
 

--- a/mgc/cli/cmd/root.go
+++ b/mgc/cli/cmd/root.go
@@ -50,6 +50,7 @@ can generate a command line on-demand for Rest manipulation`,
 	configureOutputColor(rootCmd, nil)
 	addOutputFlag(rootCmd)
 	addLogFilterFlag(rootCmd, getLogFilterConfig(sdk))
+	addLogDebugFlag(rootCmd)
 	addTimeoutFlag(rootCmd)
 	addWaitTerminationFlag(rootCmd)
 	addRetryUntilFlag(rootCmd)


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

<!-- Describe what your PR does here, change log, etc -->

Show the logs at debug level

## Related Issues
<!--
Use keywords like 'close' or 'solves' to link this PR to an issue.
For example:

- Closes #12345
- Unblocks #54321
- This PR solves #12345
-->

- Closes #756

## How to test it

<!-- Describe how the reviewers can test your feature. -->

run 
1. `go run . object-storage objects list  --cli.show-cli-globals`
2. `go run . object-storage objects list <bucket-name> --debug`
3. `go run . object-storage objects list <bucket-name> -d`
4. `go run . object-storage objects list my-bucket -l "info+:*" --debug` (debug takes precedence over cli.logs)



## Visual reference

<!--
Please include screenshots, gifs or recordings
For example: if this is a bug fix, provide before and after screenshots

<img width="350" alt="Screenshot of bug fix" src="your-image-url-here">

Before | After
:-:|:-:
<img width="350" alt="Screenshot of screen pre bug fix" src="your-image-url-here"> | <img width="350" alt="Screenshot of screen post bug fix" src="your-image-url-here">
-->
