### PR TITLE
fix(pre-commit): run apply customization script on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,10 +36,9 @@ repos:
         stages: [pre-commit]
     -   id: apply-oapi-customizations
         name: apply-oapi-customizations
-        language: python
+        language: system
         types_or: [yaml]
         entry: bash -c './scripts/oapi_apply_customizations.sh'
-        additional_dependencies: [PyYAML, typing, argparse]
         stages: [pre-commit]
     -   id: oapi-index-gen
         name: oapi-index-gen


### PR DESCRIPTION
## Description
oapi_apply_customizations.sh should run on every commit, but that wasn't happening. I applied this small fix to get it right

## How to test
- Modify a openapi-customization
- Try to commit this change
- pre-commit gonna fail and apply the change to the refered openapi

## Visual Reference
![Captura de tela de 2024-02-02 15-15-25](https://github.com/MagaluCloud/magalu/assets/110136151/bfc154ee-e3d0-4d69-a051-d796d51d1746)
