### PR TITLE
feat(object-storage): check for invalid item path on delete object

### DIFF
--- a/mgc/sdk/static/object_storage/common/delete.go
+++ b/mgc/sdk/static/object_storage/common/delete.go
@@ -208,6 +208,10 @@ func Delete(ctx context.Context, params DeleteObjectParams, cfg Config) (err err
 	reportProgress(reportMsg, progress, progress, progress_report.UnitsNone, nil)
 
 	resp, err := SendRequest(ctx, req)
+	if resp.StatusCode == 204 {
+		return fmt.Errorf("Couldn't find the referred item. Please provide a valid path!")
+	}
+
 	if err != nil {
 		reportProgress(reportMsg, progress, progress, progress_report.UnitsNone, err)
 		return


### PR DESCRIPTION
## Description
When trying to delete an item with an invalid path we were returning Done, as if it had been successful. This is because the `delete-object` returns 204 No Content when there is an invalid key but we were not checking it. This PR solves this

## Related tasks
- Closes #811 

## How to test
Run `mgc object-storage objects delete --dst <bucket-name>/<wrong-path>`
You are expected to see the error message `Couldn't find the referred item. Please provide a valid path!`

## Visual Reference
![Captura de tela de 2024-02-07 15-54-43](https://github.com/MagaluCloud/magalu/assets/110136151/17b4781d-0fed-40bb-bd36-81b77b8ab288)
