### PR TITLE
fix(object-storage): drop check for 204 status response on delete

### DIFF
--- a/mgc/sdk/static/object_storage/common/delete.go
+++ b/mgc/sdk/static/object_storage/common/delete.go
@@ -208,10 +208,6 @@ func Delete(ctx context.Context, params DeleteObjectParams, cfg Config) (err err
 	reportProgress(reportMsg, progress, progress, progress_report.UnitsNone, nil)
 
 	resp, err := SendRequest(ctx, req)
-	if resp.StatusCode == 204 {
-		return fmt.Errorf("Couldn't find the referred item. Please provide a valid path!")
-	}
-
 	if err != nil {
 		reportProgress(reportMsg, progress, progress, progress_report.UnitsNone, err)
 		return


### PR DESCRIPTION
## Description
Correction to  #815 , since we realised that only checking the response status is not enough to validate a valid object key 