### PR TITLE
feat(build-release-script): generate multiple builds in subdirs

### DIFF
--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -12,8 +12,8 @@ LDFLAGS=${LDFLAGS:-"-s -w"}
 DESIRED_DIST_REGEXP=${DESIRED_DIST_REGEXP:-"^\(linux\|darwin\|windows\)/\(amd64\|arm64\)"}
 CHECK_RELEASE=${CHECK_RELEASE:-1}
 TERRAFORM_ENTRYPOINT=${TERRAFORM_ENTRYPOINT:-mgc/terraform-provider-mgc/main.go}
-TERRAFORM_BUILD_DIR=${TERRAFORM_BUILD_DIR:-build/terraform}
 TERRAFORM_NAME=${TERRAFORM_NAME:-terraform-provider-mgc}
+TERRAFORM_SRCDIR=${TERRAFORM_SRCDIR:-$(dirname $TERRAFORM_ENTRYPOINT)}
 
 if [ -z "$VERSION" ]; then
     VERSION=`git log -1 '--pretty=format:%(describe:tags)'`
@@ -27,22 +27,32 @@ source ./scripts/tf_generate_docs.sh
 
 rm -rf "$BUILDDIR"
 mkdir -p "$BUILDDIR"
-mkdir -p "$TERRAFORM_BUILD_DIR"
 
 for D in `go tool dist list | grep "$DESIRED_DIST_REGEXP"`; do
     OS=`echo "$D" | cut -d/ -f1`
     ARCH=`echo "$D" | cut -d/ -f2`
     EXT=`if [ "$OS" = "windows" ]; then echo ".exe"; fi`
-    # BUILD CLI
-    GOOS="$OS" GOARCH="$ARCH" go build -buildvcs=false -tags "$TAGS" -ldflags "$LDFLAGS -X magalu.cloud/sdk.Version=$VERSION" -o "$BUILDDIR/$NAME-$OS-$ARCH-$VERSION$EXT" "$ENTRYPOINT"
-    # BUILD TERRAFORM PROVIDER
-    GOOS="$OS" GOARCH="$ARCH" go build -buildvcs=false -tags "$TAGS" -ldflags "$LDFLAGS -X magalu.cloud/sdk.Version=$VERSION" -o "$TERRAFORM_BUILD_DIR/$TERRAFORM_NAME.$OS-$ARCH-$VERSION$EXT" "$TERRAFORM_ENTRYPOINT"
-done
 
-cp mgc/cli/RUNNING.md "$BUILDDIR/README.md"
-cp -a mgc/cli/examples "$BUILDDIR"
-cp mgc/sdk/openapi/README.md "$BUILDDIR/OPENAPI.md"
-cp -r share "$BUILDDIR"
-cp -r mgc/terraform-provider-mgc/docs "$TERRAFORM_BUILD_DIR"
-cp -r mgc/terraform-provider-mgc/user-guide.md "$TERRAFORM_BUILD_DIR"
-cp -r mgc/terraform-provider-mgc/install.sh "$TERRAFORM_BUILD_DIR"
+    SUBDIR="$BUILDDIR/$NAME-cli-$OS-$ARCH-$VERSION"
+    mkdir -p "$SUBDIR"
+
+    # BUILD CLI
+    GOOS="$OS" GOARCH="$ARCH" go build -buildvcs=false -tags "$TAGS" -ldflags "$LDFLAGS -X magalu.cloud/sdk.Version=$VERSION" -o "$SUBDIR/$NAME$EXT" "$ENTRYPOINT"
+
+    # Copy cli additional files
+    cp mgc/cli/RUNNING.md "$SUBDIR/README.md"
+    cp -a mgc/cli/examples "$SUBDIR"
+    cp mgc/sdk/openapi/README.md "$SUBDIR/OPENAPI.md"
+    cp -r share "$SUBDIR"
+
+    SUBDIR="$BUILDDIR/$NAME-terraform-$OS-$ARCH-$VERSION"
+    mkdir -p "$SUBDIR"
+
+    # Build Terraform provider
+    GOOS="$OS" GOARCH="$ARCH" go build -buildvcs=false -tags "$TAGS" -ldflags "$LDFLAGS -X magalu.cloud/sdk.Version=$VERSION" -o "$SUBDIR/$TERRAFORM_NAME$EXT" "$TERRAFORM_ENTRYPOINT"
+
+    # Copy terraform additional files
+    cp -r $TERRAFORM_SRCDIR/docs "$SUBDIR"
+    cp -r $TERRAFORM_SRCDIR/user-guide.md "$SUBDIR"
+    cp -r $TERRAFORM_SRCDIR/install.sh "$SUBDIR"
+done


### PR DESCRIPTION
## Description
This PR modifies the build_release script to generate multiple independent builds in the build directory. We should have a subdirectory in the build folder for each ARCH/OS. The Cli and terraform executables should be separated, each including its own documentation 

## Related issues

## How to test
Run `./scripts/build_release.sh` and then check if the files in build directory are matching the description

## Visual Reference
- Before
![Captura de tela de 2024-02-15 23-06-07](https://github.com/MagaluCloud/magalu/assets/110136151/0c1e6adf-6c06-4c2c-b9a8-bd4b38f9364e)

- After
![Captura de tela de 2024-02-15 23-05-19](https://github.com/MagaluCloud/magalu/assets/110136151/f2354f9a-682e-4d43-9a1f-8f59a44ccf5f)
