### PR TITLE
fix(object-storage): return error on sync with invalid bucket

### DIFF
--- a/mgc/sdk/static/object_storage/objects/sync.go
+++ b/mgc/sdk/static/object_storage/objects/sync.go
@@ -127,7 +127,7 @@ func sync(ctx context.Context, params syncParams, cfg common.Config) (result cor
 	}
 
 	for entry := range dstObjects {
-		if entry.Err() != nil {
+		if err := entry.Err(); err != nil {
 			objErr = append(objErr, err)
 			continue
 		}


### PR DESCRIPTION
## Description
Trying to use the sync command with a invalid bucket was causing nil pointer error. This PR solves it

## Related issue
- Closes #821 

## How to test
Run the sync command with a invalid dst

## Visual Reference
![image](https://github.com/MagaluCloud/magalu/assets/110136151/e7573b18-eb3f-4f26-a3b1-1495ebe6beb3)
