### PR TITLE
fix: change clientId pre-prod

### DIFF
--- a/mgc/sdk/sdk.go
+++ b/mgc/sdk/sdk.go
@@ -216,7 +216,7 @@ func init() {
 			TokenExchangeUrl: "https://id.magalu.com/oauth/token/exchange",
 		},
 		"pre-prod": { // TODO update this links to the correct ones
-			ClientId:         "cw9qpaUl2nBiC8PVjNFN5jZeb2vTd_1S5cYs1FhEXh0",
+			ClientId:         "dByqQVtHcs07b_O9jpUDgfV5UCskh9TbC64WUXEdVHE",
 			RedirectUri:      "http://localhost:8095/callback",
 			LoginUrl:         "https://idmagalu-preprod.luizalabs.com/login",
 			TokenUrl:         "https://idpa-api-preprod.luizalabs.com/oauth/token",


### PR DESCRIPTION
I created a clientId for the preprod environment because we didn't have one yet.

The clientId is now valid, but there are still some scope permissions missing; in this case, the service owners need to approve them.

![image](https://github.com/MagaluCloud/magalu/assets/13826728/7f245439-fd3c-4ccf-a241-f86e4d3c3b94)
