### PR TITLE
feat(blueprints): add promptInput support

### DIFF
--- a/mgc/sdk/blueprint/executor.go
+++ b/mgc/sdk/blueprint/executor.go
@@ -30,6 +30,10 @@ func newExecutor(spec *childSpec, logger *zap.SugaredLogger, refResolver *core.B
 		exec = core.NewConfirmableExecutor(exec, core.ConfirmPromptWithTemplate(execSpec.Confirm))
 	}
 
+	if execSpec.PromptInput != nil {
+		exec = core.NewPromptInputExecutor(exec, core.NewPromptInput(execSpec.PromptInput.MessageTemplate, execSpec.PromptInput.ConfirmValueTemplate))
+	}
+
 	if execSpec.WaitTermination != nil {
 		exec, err = execSpec.WaitTermination.Build(exec, func(result core.ResultWithValue) any {
 			if result, ok := core.ResultAs[*executorResult](result); ok {

--- a/mgc/sdk/blueprint/executor_spec.go
+++ b/mgc/sdk/blueprint/executor_spec.go
@@ -45,6 +45,12 @@ type executorSpec struct {
 	Confirm         string                      `json:"confirm,omitempty"`
 	WaitTermination *core.WaitTerminationConfig `json:"waitTermination,omitempty"`
 	OutputFlag      string                      `json:"outputFlag,omitempty"`
+	PromptInput     *PromptInputSpec            `json:"promptInput,omitempty"`
+}
+
+type PromptInputSpec struct {
+	MessageTemplate      string `json:"message,omitempty"`
+	ConfirmValueTemplate string `json:"confirmValue,omitempty"`
 }
 
 func (e *executorSpec) isEmpty() bool {

--- a/mgc/sdk/blueprint/linker.go
+++ b/mgc/sdk/blueprint/linker.go
@@ -130,6 +130,9 @@ func (l *linker) CreateExecutor(originalResult core.Result) (target core.Executo
 	if _, ok := core.ExecutorAs[core.ConfirmableExecutor](target); ok {
 		exec = core.NewLinkConfirmableExecutor(exec)
 	}
+	if _, ok := core.ExecutorAs[core.PromptInputExecutor](target); ok {
+		exec = core.NewLinkPromptInputExecutor(exec)
+	}
 
 	return exec, nil
 }


### PR DESCRIPTION
## Description
Add promptInput support on blueprints

## Related issues
- Closes #852

# How to test
Go to any blueprints file and add something like
```yaml
promptInput:
          message: Testando promptInput {{.confirmationValue}}
          confirmValue: abcd123
```



## Visual Reference
![Captura de tela de 2024-02-22 10-54-10](https://github.com/MagaluCloud/magalu/assets/110136151/fa08dd2e-f423-4ca8-aa72-84ca6ba66ede)
