### PR TITLE
fix(cli): maintain consistency in select command order of args

### DIFF
--- a/mgc/cli/cmd/select_helper.go
+++ b/mgc/cli/cmd/select_helper.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -27,11 +28,17 @@ func (c selectorChoice) String() string {
 	switch v := c.value.(type) {
 	case map[string]any:
 		s := ""
-		for key, value := range v {
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		slices.Sort(keys)
+
+		for _, key := range keys {
 			if s != "" {
 				s += ", "
 			}
-			s += fmt.Sprintf("%s=%#v", key, value)
+			s += fmt.Sprintf("%s=%#v", key, v[key])
 		}
 		return s
 	default:


### PR DESCRIPTION
## Visual Reference

| Before |
| - |
| <img width="1265" alt="image" src="https://github.com/MagaluCloud/magalu/assets/63523165/9b3e6698-6600-4089-9fc7-93bc094cbf54"> |
| After |
| <img width="1267" alt="image" src="https://github.com/MagaluCloud/magalu/assets/63523165/68c012db-8f9b-4178-b535-a1d3043743cf"> |