### PR TITLE
fix(bytes-reporter): add safer return on BytesReporterFromContext

### DIFF
--- a/mgc/core/progress_report/bytes_reporter.go
+++ b/mgc/core/progress_report/bytes_reporter.go
@@ -40,7 +40,10 @@ func NewBytesReporterContext(
 }
 
 func BytesReporterFromContext(ctx context.Context) *BytesReporter {
-	return ctx.Value(bytesProgressReporterKey).(*BytesReporter)
+	if reporter, ok := ctx.Value(bytesProgressReporterKey).(*BytesReporter); ok {
+		return reporter
+	}
+	return nil
 }
 
 func (r *BytesReporter) Start() {


### PR DESCRIPTION
## Description
Corrected a null pointer error that occurred in object deletion operations due to a force cast in BytesReporterFromContext. This PR adds a safer return

