### PR TITLE
feat: change scopes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .ONESHELL:
 # TODO: Develop additional commands: release features, etc., and upon completion, enhance the README.
-build:
+
+build-spec:
 	python3 ./scripts/oapi_index_gen.py "--embed=mgc/sdk/openapi/embed_loader.go" mgc/cli/openapis
+	cd mgc/cli; echo "Building...."; \
+	go build -tags "embed" -o mgc
+
+build:
 	cd mgc/cli; echo "Building...."; \
 	go build -tags "embed" -o mgc

--- a/mgc/sdk/static/object_storage/api_key/common.go
+++ b/mgc/sdk/static/object_storage/api_key/common.go
@@ -1,6 +1,9 @@
 package api_key
 
-const name_ObjectStorage = "Object Storage"
+const (
+	name_ObjectStorage = "Object Storage"
+	scope_PA           = "pa:cloud-cli:features"
+)
 
 type apiKeysResult struct {
 	UUID          string  `json:"uuid"`

--- a/mgc/sdk/static/object_storage/api_key/create.go
+++ b/mgc/sdk/static/object_storage/api_key/create.go
@@ -23,7 +23,7 @@ type createParams struct {
 var getCreate = utils.NewLazyLoader[core.Executor](func() core.Executor {
 	executor := core.NewStaticExecute(
 		core.DescriptorSpec{
-			Scopes:      core.Scopes{"pa:api-keys:create"},
+			Scopes:      core.Scopes{scope_PA},
 			Name:        "create",
 			Description: "Create new credentials used for Object Storage requests",
 		},

--- a/mgc/sdk/static/object_storage/api_key/list.go
+++ b/mgc/sdk/static/object_storage/api_key/list.go
@@ -16,7 +16,7 @@ import (
 var getList = utils.NewLazyLoader[core.Executor](func() core.Executor {
 	return core.NewStaticExecuteSimple(
 		core.DescriptorSpec{
-			Scopes:      core.Scopes{"pa:api-keys:read"},
+			Scopes:      core.Scopes{scope_PA},
 			Name:        "list",
 			Description: "List valid Object Storage credentials",
 		},

--- a/mgc/sdk/static/object_storage/api_key/revoke.go
+++ b/mgc/sdk/static/object_storage/api_key/revoke.go
@@ -19,7 +19,7 @@ type revokeParams struct {
 var getRevoke = utils.NewLazyLoader[core.Executor](func() core.Executor {
 	var exec core.Executor = core.NewStaticExecute(
 		core.DescriptorSpec{
-			Scopes:      core.Scopes{"pa:api-keys:revoke"},
+			Scopes:      core.Scopes{scope_PA},
 			Name:        "revoke",
 			Description: "Revoke credentials used in Object Storage requests",
 		},


### PR DESCRIPTION
OUT: 
```
pa:api-keys:create
pa:api-keys:read
pa:api-keys:revoke
```

IN:  `pa:cloud-cli:features`

```
magalu git:(feat/change-escopes) mgc auth scopes list-current
[
 "block-storage.read",
 "block-storage.write",
 "cpo:read",
 "cpo:write",
 "dbaas.read",
 "dbaas.write",
 "mke.read",
 "mke.write",
 "network.read",
 "network.write",
 "object-storage.read",
 "object-storage.write",
 "openid",
 "pa:cloud-cli:features",
 "pa:scopes-approval:read",
 "virtual-machine.read",
 "virtual-machine.write"
]
```

ps. The scope `pa:scopes-approval:read` is tagged as default at id.Magalu, i made a note to remove it.