### PR TITLE
feat(scopes): implement an add-all command to include all scopes

### DIFF
--- a/mgc/sdk/static/auth/scopes/add_all.go
+++ b/mgc/sdk/static/auth/scopes/add_all.go
@@ -1,0 +1,76 @@
+package scopes
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"go.uber.org/zap"
+	"magalu.cloud/core"
+	"magalu.cloud/core/auth"
+	"magalu.cloud/core/utils"
+)
+
+var addAllLogger = utils.NewLazyLoader(func() *zap.SugaredLogger {
+	return logger().Named("add-all")
+})
+
+var getAddAll = utils.NewLazyLoader(func() core.Executor {
+	return core.NewStaticExecuteSimple(
+		core.DescriptorSpec{
+			Name:        "add-all",
+			Description: "Add all scopes from all operations to the current access token.",
+			Summary:     "Add all scopes to the current access token",
+		},
+		addAll,
+	)
+})
+
+func addAll(ctx context.Context) (core.Scopes, error) {
+	a := auth.FromContext(ctx)
+	if a == nil {
+		return nil, fmt.Errorf("programming error: context did not contain SDK Auth information")
+	}
+
+	allScopes, err := ListAllAvailable(ctx)
+	if err != nil {
+		addAllLogger().Warnw("unable to list all possible scopes", "err", err)
+		return nil, fmt.Errorf("unable to list all available scopes: %w", err)
+	}
+
+	currentScopes, err := a.CurrentScopes()
+	if err != nil {
+		addAllLogger().Warnw("unable to get current scopes from auth", "err", err)
+		return nil, err
+	}
+
+	currentScopes.Add(allScopes...)
+	_, err = a.SetScopes(ctx, currentScopes)
+	if err != nil {
+		addAllLogger().Warnw("token exchange failed", "scopes", currentScopes, "err", err)
+		return nil, err
+	}
+
+	currentScopes, err = a.CurrentScopes()
+	if err != nil {
+		addAllLogger().Warnw(
+			"add-all operation was successful but unable to get current scopes to check",
+			"err", err,
+		)
+		return currentScopes, nil
+	}
+
+	missing := core.Scopes{}
+	for _, scope := range allScopes {
+		if !slices.Contains(currentScopes, scope) {
+			missing.Add(scope)
+		}
+	}
+
+	if len(missing) > 0 {
+		return currentScopes, fmt.Errorf("request was successful but resulting scopes are not as expected. Missing: %v", missing)
+	}
+
+	slices.Sort(currentScopes)
+	return currentScopes, nil
+}

--- a/mgc/sdk/static/auth/scopes/group.go
+++ b/mgc/sdk/static/auth/scopes/group.go
@@ -17,6 +17,7 @@ access token used in all other operations.`,
 		func() []core.Descriptor {
 			return []core.Descriptor{
 				getAdd(),
+				getAddAll(),
 				getListAll(),
 				getListCurrent(),
 				getRemove(),

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -128,6 +128,24 @@
       "configs": {
        "type": "object"
       },
+      "description": "Add all scopes from all operations to the current access token.",
+      "isInternal": false,
+      "name": "add-all",
+      "parameters": {
+       "type": "object"
+      },
+      "result": {
+       "items": {
+        "type": "string"
+       },
+       "type": "array"
+      },
+      "version": ""
+     },
+     {
+      "configs": {
+       "type": "object"
+      },
       "description": "List all available scopes for all commands",
       "isInternal": false,
       "name": "list-all",

--- a/script-qa/cli-help/auth/scopes/add-all/help.txt
+++ b/script-qa/cli-help/auth/scopes/add-all/help.txt
@@ -1,0 +1,11 @@
+Add all scopes from all operations to the current access token.
+
+Usage:
+  ./cli auth scopes add-all [flags]
+
+Flags:
+  -h, --help   help for add-all
+
+Global Flags:
+      --cli.show-cli-globals   Show all CLI global flags on usage text
+

--- a/script-qa/cli-help/auth/scopes/help.txt
+++ b/script-qa/cli-help/auth/scopes/help.txt
@@ -8,6 +8,7 @@ Usage:
 
 Commands:
   add          Add new scopes to the current access token
+  add-all      Add all scopes to the current access token
   list-all     List all available scopes for all commands
   list-current List scopes present in the current access token
   remove       Remove scopes from the current scopes in the access token.


### PR DESCRIPTION
## Description
This PR implements a command to add all the scopes 

## Related issues
- closes  #915

## How to test
- If you are missing any scope, run the `auth scopes add-all` command and check if it adds the ones that were missing

## Visual Reference
- Listing the current scopes and then running add-all
![Captura de tela de 2024-03-04 12-07-56](https://github.com/MagaluCloud/magalu/assets/110136151/ec9f068d-2221-4951-be13-253e5c04f00c)
