### PR TITLE
fix(object-storage): check if the source contains a key 

### DIFF
--- a/mgc/sdk/static/object_storage/objects/download.go
+++ b/mgc/sdk/static/object_storage/objects/download.go
@@ -27,6 +27,10 @@ var getDownload = utils.NewLazyLoader[core.Executor](func() core.Executor {
 })
 
 func download(ctx context.Context, p common.DownloadObjectParams, cfg common.Config) (result core.Value, err error) {
+	if p.Source.Path() == "" {
+		return nil, core.UsageError{Err: fmt.Errorf("invalid source specified. Please include the object key in addition to the bucket name")}
+	}
+
 	dst, err := common.GetDownloadFileDst(p.Destination, p.Source)
 	if err != nil {
 		return nil, fmt.Errorf("no destination specified and could not use local dir: %w", err)


### PR DESCRIPTION
## Description
We must check if the provided source in object download operation contains a key of if it is only a bucket name

## Related issues
- Closes #922

## How to test
- Run `go run . object-storage objects download --src <bucket-name> --dst <dst>`
You are expected to receive a error since you are not including the object key in src 

## Visual reference
![Captura de tela de 2024-03-07 10-23-53](https://github.com/MagaluCloud/magalu/assets/110136151/9eac6c49-bb0f-4dc1-9f1c-29f07ab9b36a)
