### PR TITLE
chore(object-storage): rename commands

### DIFF
--- a/mgc/sdk/static/object_storage/api_key/get_current.go
+++ b/mgc/sdk/static/object_storage/api_key/get_current.go
@@ -13,7 +13,7 @@ import (
 var getGetCurrent = utils.NewLazyLoader[core.Executor](func() core.Executor {
 	return core.NewStaticExecuteSimple(
 		core.DescriptorSpec{
-			Name:        "get-current",
+			Name:        "current",
 			Description: "Get the current Object Storage credentials",
 		},
 		getCurrent,

--- a/mgc/sdk/static/object_storage/api_key/set_current.go
+++ b/mgc/sdk/static/object_storage/api_key/set_current.go
@@ -16,7 +16,7 @@ type selectParams struct {
 var getSetCurrent = utils.NewLazyLoader[core.Executor](func() core.Executor {
 	executor := core.NewStaticExecute(
 		core.DescriptorSpec{
-			Name:        "set-current",
+			Name:        "set",
 			Description: "Change current Object Storage credential to selected",
 		},
 		setCurrent,

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -19411,6 +19411,35 @@
       "configs": {
        "type": "object"
       },
+      "description": "Get the current Object Storage credentials",
+      "isInternal": false,
+      "name": "current",
+      "parameters": {
+       "type": "object"
+      },
+      "result": {
+       "properties": {
+        "access_key_id": {
+         "description": "Access key id value",
+         "type": "string"
+        },
+        "secret_access_key": {
+         "description": "Secret access key value",
+         "type": "string"
+        }
+       },
+       "required": [
+        "access_key_id",
+        "secret_access_key"
+       ],
+       "type": "object"
+      },
+      "version": ""
+     },
+     {
+      "configs": {
+       "type": "object"
+      },
       "description": "Get details about a specific key",
       "isInternal": false,
       "name": "get",
@@ -19462,35 +19491,6 @@
         "key_pair_id",
         "key_pair_secret",
         "start_validity"
-       ],
-       "type": "object"
-      },
-      "version": ""
-     },
-     {
-      "configs": {
-       "type": "object"
-      },
-      "description": "Get the current Object Storage credentials",
-      "isInternal": false,
-      "name": "get-current",
-      "parameters": {
-       "type": "object"
-      },
-      "result": {
-       "properties": {
-        "access_key_id": {
-         "description": "Access key id value",
-         "type": "string"
-        },
-        "secret_access_key": {
-         "description": "Secret access key value",
-         "type": "string"
-        }
-       },
-       "required": [
-        "access_key_id",
-        "secret_access_key"
        ],
        "type": "object"
       },
@@ -19590,7 +19590,7 @@
       },
       "description": "Change current Object Storage credential to selected",
       "isInternal": false,
-      "name": "set-current",
+      "name": "set",
       "parameters": {
        "properties": {
         "uuid": {

--- a/script-qa/cli-help/object-storage/api-key/current/help.txt
+++ b/script-qa/cli-help/object-storage/api-key/current/help.txt
@@ -1,10 +1,10 @@
 Get the current Object Storage credentials
 
 Usage:
-  ./cli object-storage api-key get-current [flags]
+  ./cli object-storage api-key current [flags]
 
 Flags:
-  -h, --help   help for get-current
+  -h, --help   help for current
 
 Global Flags:
       --cli.show-cli-globals   Show all CLI global flags on usage text

--- a/script-qa/cli-help/object-storage/api-key/help.txt
+++ b/script-qa/cli-help/object-storage/api-key/help.txt
@@ -5,15 +5,15 @@ Usage:
   ./cli object-storage api-key [command]
 
 Commands:
-  create         Create new credentials used for Object Storage requests
-  get            Get details about a specific key
-  get-current    Get the current Object Storage credentials
-  list           List valid Object Storage credentials
-  revoke         Revoke credentials used in Object Storage requests
-  set-current    Change current Object Storage credential to selected
+  create      Create new credentials used for Object Storage requests
+  current     Get the current Object Storage credentials
+  get         Get details about a specific key
+  list        List valid Object Storage credentials
+  revoke      Revoke credentials used in Object Storage requests
+  set         Change current Object Storage credential to selected
 
 Additional Commands:
-  select-current call "list", prompt selection and then "set-current"
+  select      call "list", prompt selection and then "set"
 
 Flags:
   -h, --help   help for api-key

--- a/script-qa/cli-help/object-storage/api-key/set/help.txt
+++ b/script-qa/cli-help/object-storage/api-key/set/help.txt
@@ -1,10 +1,10 @@
 Change current Object Storage credential to selected
 
 Usage:
-  ./cli object-storage api-key set-current [uuid] [flags]
+  ./cli object-storage api-key set [uuid] [flags]
 
 Flags:
-  -h, --help          help for set-current
+  -h, --help          help for set
       --uuid string   UUID of api key to select (required)
 
 Global Flags:


### PR DESCRIPTION
## Description
Renaming the object-storage api-key commands. More context: [link](https://chat.google.com/room/AAAATfofxEQ/hMhciwU8170/hMhciwU8170?cls=10)

## Closes

## Visual Reference
Before 
```
Commands:
  create      Create new credentials used for Object Storage requests
  get            Get details about a specific key
  get-current    Get the current Object Storage credentials
  list           List valid Object Storage credentials
  revoke         Revoke credentials used in Object Storage requests
  set-current    Change current Object Storage credential to selected

Additional Commands:
  select-current call "list", prompt selection and then "set-current"
 
```
After
```
Commands:
  create      Create new credentials used for Object Storage requests
  current     Get the current Object Storage credentials
  get         Get details about a specific key
  list        List valid Object Storage credentials
  revoke      Revoke credentials used in Object Storage requests
  set         Change current Object Storage credential to selected

Additional Commands:
  select      call "list", prompt selection and then "set"
```