### PR TITLE
fix: filter rules with aws behaviour

### DIFF
--- a/mgc/core/pipeline/filter.go
+++ b/mgc/core/pipeline/filter.go
@@ -157,6 +157,24 @@ func (r FilterRuleAnd[T]) RecursiveWrap(wrapper filterRuleWrapper[T]) FilterRule
 	return &FilterRuleAnd[T]{wrapFilterRuleLogArray[T](r.And, wrapper)}
 }
 
+// All values must match FilterInclude or FilterUnknown. If so, return FilterInclude. Otherwise, return FilterExclude
+type FilterRuleFirst[T any] struct {
+	Filters []FilterRule[T]
+}
+
+func (r FilterRuleFirst[T]) Filter(ctx context.Context, entry T) FilterStatus {
+	for i := len(r.Filters) - 1; i >= 0; i-- {
+		if filter := r.Filters[i].Filter(ctx, entry); filter != FilterUnknown {
+			return filter
+		}
+	}
+	return FilterUnknown
+}
+
+func (r FilterRuleFirst[T]) RecursiveWrap(wrapper filterRuleWrapper[T]) FilterRule[T] {
+	return &FilterRuleAnd[T]{wrapFilterRuleLogArray[T](r.Filters, wrapper)}
+}
+
 var _ FilterRule[any] = (*FilterRuleAnd[any])(nil)
 var _ FilterRuleRecursiveWrapper[any] = (*FilterRuleAnd[any])(nil)
 

--- a/mgc/sdk/static/object_storage/common/filter.go
+++ b/mgc/sdk/static/object_storage/common/filter.go
@@ -19,8 +19,8 @@ func ApplyFilters(ctx context.Context, entries <-chan pipeline.WalkDirEntry, par
 	filters := []pipeline.FilterRule[pipeline.WalkDirEntry]{}
 	for _, filter := range params {
 		if filter.Include != "" {
-			filters = append(filters, pipeline.FilterRuleIncludeOnly[pipeline.WalkDirEntry]{
-				Pattern: pipeline.FilterWalkDirEntryIncludeGlobMatch{Pattern: filter.Include, CancelOnError: cancel},
+			filters = append(filters, pipeline.FilterWalkDirEntryIncludeGlobMatch{
+				Pattern: filter.Include, CancelOnError: cancel,
 			})
 		}
 		if filter.Exclude != "" {
@@ -34,6 +34,6 @@ func ApplyFilters(ctx context.Context, entries <-chan pipeline.WalkDirEntry, par
 		return entries
 	}
 
-	filterRule := pipeline.FilterRuleAnd[pipeline.WalkDirEntry]{And: filters}
+	filterRule := pipeline.FilterRuleFirst[pipeline.WalkDirEntry]{Filters: filters}
 	return pipeline.Filter[pipeline.WalkDirEntry](ctx, entries, filterRule)
 }


### PR DESCRIPTION
Filters were being used in a simple "and" pattern. This fixes it to work like AWS works, by including or excluding pattern matches and doing nothing with the rest. This allows a "or" pattern.