### PR TITLE
chore: add apikey and improve headless login

### DIFF
--- a/mgc/sdk/static/object_storage/api_key/add.go
+++ b/mgc/sdk/static/object_storage/api_key/add.go
@@ -1,0 +1,38 @@
+package api_key
+
+import (
+	"context"
+
+	mgcAuthPkg "magalu.cloud/core/auth"
+	"magalu.cloud/core/utils"
+
+	"magalu.cloud/core"
+)
+
+type addParams struct {
+	KeyPairID     string `json:"keyId" jsonschema_description:"ID of api key to use" mgc:"positional"`
+	KeyPairSecret string `json:"keySecret" jsonschema_description:"Secret of api key to use" mgc:"positional"`
+}
+
+var getAdd = utils.NewLazyLoader[core.Executor](func() core.Executor {
+	executor := core.NewStaticExecute(
+		core.DescriptorSpec{
+			Name:        "add",
+			Description: "Change current Object Storage credential",
+			IsInternal:  utils.BoolPtr(true),
+		},
+		addKey,
+	)
+
+	return core.NewExecuteResultOutputOptions(executor, func(exec core.Executor, result core.Result) string {
+		return "template=Keys changed successfully\n"
+	})
+})
+
+func addKey(ctx context.Context, parameter addParams, _ struct{}) (*apiKeysResult, error) {
+	if err := mgcAuthPkg.FromContext(ctx).SetAccessKey(parameter.KeyPairID, parameter.KeyPairSecret); err != nil {
+		return nil, err
+	}
+
+	return &apiKeysResult{KeyPairID: parameter.KeyPairID, KeyPairSecret: parameter.KeyPairSecret}, nil
+}

--- a/mgc/sdk/static/object_storage/api_key/group.go
+++ b/mgc/sdk/static/object_storage/api_key/group.go
@@ -19,6 +19,7 @@ var GetGroup = utils.NewLazyLoader(func() core.Grouper {
 				getList(),
 				getRevoke(),
 				getSetCurrent(),
+				getAdd(),
 			}
 		},
 	)

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -36,6 +36,11 @@
     "name": "login",
     "parameters": {
      "properties": {
+      "headless": {
+       "default": false,
+       "description": "Generate URL for the login at local environment",
+       "type": "boolean"
+      },
       "qrcode": {
        "default": false,
        "description": "Generate a qrcode for the login URL",
@@ -19648,6 +19653,72 @@
   "children": [
    {
     "children": [
+     {
+      "configs": {
+       "type": "object"
+      },
+      "description": "Change current Object Storage credential",
+      "isInternal": true,
+      "name": "add",
+      "parameters": {
+       "properties": {
+        "keyId": {
+         "description": "ID of api key to use",
+         "type": "string"
+        },
+        "keySecret": {
+         "description": "Secret of api key to use",
+         "type": "string"
+        }
+       },
+       "required": [
+        "keyId",
+        "keySecret"
+       ],
+       "type": "object"
+      },
+      "result": {
+       "properties": {
+        "description": {
+         "type": "string"
+        },
+        "end_validity": {
+         "type": "string"
+        },
+        "key_pair_id": {
+         "type": "string"
+        },
+        "key_pair_secret": {
+         "type": "string"
+        },
+        "name": {
+         "type": "string"
+        },
+        "revoked_at": {
+         "type": "string"
+        },
+        "start_validity": {
+         "type": "string"
+        },
+        "tenant_name": {
+         "type": "string"
+        },
+        "uuid": {
+         "type": "string"
+        }
+       },
+       "required": [
+        "uuid",
+        "name",
+        "description",
+        "key_pair_id",
+        "key_pair_secret",
+        "start_validity"
+       ],
+       "type": "object"
+      },
+      "version": ""
+     },
      {
       "configs": {
        "type": "object"

--- a/script-qa/cli-help/auth/login/help.txt
+++ b/script-qa/cli-help/auth/login/help.txt
@@ -6,6 +6,7 @@ Usage:
   ./cli auth login [flags]
 
 Flags:
+      --headless               Generate URL for the login at local environment
   -h, --help                   help for login
       --qrcode                 Generate a qrcode for the login URL
       --scopes array(string)   All desired scopes for the resulting access token

--- a/script-qa/cli-help/object-storage/api-key/add/help.txt
+++ b/script-qa/cli-help/object-storage/api-key/add/help.txt
@@ -1,0 +1,13 @@
+Change current Object Storage credential
+
+Usage:
+  ./cli object-storage api-key add [key-id] [key-secret] [flags]
+
+Flags:
+  -h, --help                help for add
+      --key-id string       ID of api key to use (required)
+      --key-secret string   Secret of api key to use (required)
+
+Global Flags:
+      --cli.show-cli-globals   Show all CLI global flags on usage text
+


### PR DESCRIPTION
Improve headless login functionality.

Previously, when attempting to log in on a machine where Chrome is installed, users were compelled to utilize the browser. However, with the introduction of the `--headless` or `--qrcode` options, only the URL is generated, providing a more streamlined experience.

Additionally, reintroduce the command `add`, utilized to facilitate the addition of a new key pair.