### PR TITLE
build: use s3-tester container to work as smoke-tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,44 @@ jobs:
           VERSION: CI
           CHECK_RELEASE: 0
         run: ./scripts/build_release.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mgc-folder
+          path: build/mgc-cli-linux-amd64-CI/
+
+  test-build:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      PROFILES: ${{ secrets.tester_profiles_config }}
+    container:
+      image: ghcr.io/marmotitude/s3-tester:tests
+      volumes:
+        - ${{ github.workspace }}/build/mgc-cli-linux-amd64-CI:/tools/mgc2
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: mgc-folder
+          path: build/mgc-cli-linux-amd64-CI/
+      - name: Replace original mgc and run tests
+        # TODO: remove the line below to make passing integration tests REQUIRED
+        continue-on-error: true
+        run: |
+          cd /app
+          # mgc to be replaced
+          mgc --version
+          sha256sum `which mgc`
+          # remove original link to mgc
+          rm /usr/local/bin/mgc
+          # give execute permissions to new binary
+          chmod +x /tools/mgc2/mgc
+          # link the mgc from the mounted volume as the new mgc
+          ln -s /tools/mgc2/mgc /usr/local/bin/mgc
+          # custom mgc
+          mgc --version
+          sha256sum `which mgc`
+          ./entrypoint.sh --profiles ${{ vars.tester_profiles }} --clients mgc --tests ${{ vars.tester_tests }}
 
   pre-commit:
     needs: build


### PR DESCRIPTION
Fix TST-2402 (OBJ Kanban Force)

This patch adds a new job to the ci.yaml workflow that will use an image of the [s3-tester](https://github.com/marmotitude/s3-tester) tester tool to run tests of the generated mgc binary for every new pull request.

The idea is to make this required as soon as possible to avoid regressions on features that works on production.

The prod regions to test, as well what subset to run can be edit via Action variables [here](https://github.com/MagaluCloud/magalu/settings/variables/actions)