### PR TITLE
fix: make serverurl trailing slash optional

### DIFF
--- a/mgc/sdk/static/object_storage/common/const.go
+++ b/mgc/sdk/static/object_storage/common/const.go
@@ -32,7 +32,7 @@ const (
 	// ShortTimeFormat is the shorten time format used in the credential scope
 	shortTimeFormat = "20060102"
 
-	templateUrl = "https://{{region}}.magaluobjects.com/"
+	templateUrl = "https://{{region}}.magaluobjects.com"
 
 	unsignedPayloadHeader = "UNSIGNED-PAYLOAD"
 


### PR DESCRIPTION
This was breaking connections due to signature problems. Trailing slash is now always used

## Testing steps:
1. Go to your config file
2. Insert `serverurl: http://server.com/`
3. Run a command, such as `mgc object-storage buckets list`. It should work
4. Change `serverurl` to the same value, removing the trailing slash
5. Rerun step 3. It should work the same