### PR TITLE
fix: adjusting open api converting script to validade const and sub-objects

### DIFF
--- a/scripts/transformers/transform.py
+++ b/scripts/transformers/transform.py
@@ -18,7 +18,6 @@ from spec_fix_links import FixLinksTransformer
 from spec_create_links import CreateLinks
 from validate_openapi_specs import validate_oapi
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="Transform OAPI Spec",


### PR DESCRIPTION
This pull request adds support for converting the "const" keyword in the OpenAPI specification. It introduces a new private method `_convert_const()` that handles the conversion logic. The method sets the "enum" property to an array containing the constant value and removes the "const" property from the dictionary. This change improves the functionality of the code and ensures compatibility with the OpenAPI specification.