### PR TITLE
feat: update sync command to sync local path with bucket

### DIFF
--- a/mgc/sdk/static/object_storage/objects/sync.go
+++ b/mgc/sdk/static/object_storage/objects/sync.go
@@ -307,7 +307,11 @@ func uploadFile(ctx context.Context, local mgcSchemaPkg.URI, bucket mgcSchemaPkg
 }
 
 func deleteFile(ctx context.Context, destination mgcSchemaPkg.URI, cfg common.Config) error {
-	return nil
+	param := common.DeleteObjectParams{
+		Destination: destination,
+	}
+	_, err := deleteObject(ctx, param, cfg)
+	return err
 }
 
 func (c *UploadCounter) Increment() {

--- a/script-qa/cli-doc/object-storage/objects/help.md
+++ b/script-qa/cli-doc/object-storage/objects/help.md
@@ -22,7 +22,7 @@ Usage:
 - move-dir     Moves objects from source to destination
 - presign      Generate a pre-signed URL for accessing an object
 - public-url   Get object public url
-- sync         Synchronizes a local path to a bucket
+- sync         Synchronizes a local path with a bucket
 - upload       Upload a file to a bucket
 - upload-dir   Upload a directory to a bucket
 - versions     Retrieve all versions of an object

--- a/script-qa/cli-doc/object-storage/objects/sync/help.md
+++ b/script-qa/cli-doc/object-storage/objects/sync/help.md
@@ -1,22 +1,22 @@
-# This command uploads any file from the source to the destination if it's not present or has a different size. Additionally any file in the destination not present on the source is deleted.
+# This command uploads any file from the local path to the bucket if it is not already present or has changed.
 
 ## Usage:
 ```bash
 Usage:
-  ./mgc object-storage objects sync [src] [dst] [flags]
+  ./mgc object-storage objects sync [local] [bucket] [flags]
 ```
 
 ## Product catalog:
 - Examples:
-- ./mgc object-storage objects sync --dst="s3://my-bucket/dir/" --src="./"
+- ./mgc object-storage objects sync --bucket="my-bucket/dir/" --local="./"
 
 ## Other commands:
 - Flags:
 - --batch-size integer   Limit of items per batch to delete (range: 1 - 1000) (default 1000)
-- --delete               Deletes any item at the destination not present on the source
-- --dst uri              Full destination path to sync with the source path (required)
+- --bucket uri           Bucket path (required)
+- --delete               Deletes any item at the bucket not present on the local
 - -h, --help                 help for sync
-- --src uri              Source path to sync the remote with (required)
+- --local uri            Local path (required)
 
 ## Flags:
 ```bash

--- a/script-qa/cli-dump-tree.json
+++ b/script-qa/cli-dump-tree.json
@@ -23873,7 +23873,7 @@
        },
        "type": "object"
       },
-      "description": "This command uploads any file from the source to the destination if it's not present or has a different size. Additionally any file in the destination not present on the source is deleted.",
+      "description": "This command uploads any file from the local path to the bucket if it is not already present or has changed.",
       "isInternal": false,
       "name": "sync",
       "parameters": {
@@ -23885,27 +23885,27 @@
          "minimum": 1,
          "type": "integer"
         },
-        "delete": {
-         "default": false,
-         "description": "Deletes any item at the destination not present on the source",
-         "type": "boolean"
-        },
-        "dst": {
-         "description": "Full destination path to sync with the source path",
-         "example": "s3://my-bucket/dir/",
+        "bucket": {
+         "description": "Bucket path",
+         "example": "my-bucket/dir/",
          "format": "uri",
          "type": "string"
         },
-        "src": {
-         "description": "Source path to sync the remote with",
+        "delete": {
+         "default": false,
+         "description": "Deletes any item at the bucket not present on the local",
+         "type": "boolean"
+        },
+        "local": {
+         "description": "Local path",
          "example": "./",
          "format": "uri",
          "type": "string"
         }
        },
        "required": [
-        "src",
-        "dst"
+        "local",
+        "bucket"
        ],
        "type": "object"
       },

--- a/script-qa/cli-help/object-storage/objects/help.txt
+++ b/script-qa/cli-help/object-storage/objects/help.txt
@@ -18,7 +18,7 @@ Commands:
   move-dir     Moves objects from source to destination
   presign      Generate a pre-signed URL for accessing an object
   public-url   Get object public url
-  sync         Synchronizes a local path to a bucket
+  sync         Synchronizes a local path with a bucket
   upload       Upload a file to a bucket
   upload-dir   Upload a directory to a bucket
   versions     Retrieve all versions of an object

--- a/script-qa/cli-help/object-storage/objects/sync/help.txt
+++ b/script-qa/cli-help/object-storage/objects/sync/help.txt
@@ -1,17 +1,17 @@
-This command uploads any file from the source to the destination if it's not present or has a different size. Additionally any file in the destination not present on the source is deleted.
+This command uploads any file from the local path to the bucket if it is not already present or has changed.
 
 Usage:
-  ./mgc object-storage objects sync [src] [dst] [flags]
+  ./mgc object-storage objects sync [local] [bucket] [flags]
 
 Examples:
-  ./mgc object-storage objects sync --dst="s3://my-bucket/dir/" --src="./"
+  ./mgc object-storage objects sync --bucket="my-bucket/dir/" --local="./"
 
 Flags:
       --batch-size integer   Limit of items per batch to delete (range: 1 - 1000) (default 1000)
-      --delete               Deletes any item at the destination not present on the source
-      --dst uri              Full destination path to sync with the source path (required)
+      --bucket uri           Bucket path (required)
+      --delete               Deletes any item at the bucket not present on the local
   -h, --help                 help for sync
-      --src uri              Source path to sync the remote with (required)
+      --local uri            Local path (required)
 
 Global Flags:
       --chunk-size integer     Chunk size to consider when doing multipart requests. Specified in Mb (range: 8 - 5120) (default 8)


### PR DESCRIPTION
The sync command has been updated to sync a local path with a bucket. Previously, it was syncing a local path to a bucket. This change ensures that any file from the local path that is not already present in the bucket or has changed will be uploaded. Additionally, any file in the bucket that is not present in the local path will be deleted. The command now takes the `--local` flag for specifying the local path and the `--bucket` flag for specifying the bucket path.