### PR TITLE
feat: listen using env MGC_LISTEN_ADDRESS

### DIFF
--- a/mgc/sdk/static/auth/login.go
+++ b/mgc/sdk/static/auth/login.go
@@ -199,6 +199,10 @@ func startCallbackServer(ctx context.Context, auth *auth.Auth, isHeadless bool) 
 	// Host includes the port, then listen to specific address + port, ex: "localhost:8095"
 	addr := callbackUrl.Host
 
+	if envListenAddr := os.Getenv("MGC_LISTEN_ADDRESS"); envListenAddr != "" {
+		addr = envListenAddr + ":8095"
+	}
+
 	// Listen so we can fail early on bad address, before starting goroutine
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {


### PR DESCRIPTION
Esse pr adiciona a possibilidade de alterar o endereço de escuta do http server, isso durante o login.

Ao utilizar a env MGC_LISTEN_ADDRESS a CLI passará a utilizar ela como listen.
Atualmente era apenas com "localhost".