### PR TITLE
chore: Refactor handleResultWithReader to support YAML output

### DIFF
--- a/mgc/cli/go.mod
+++ b/mgc/cli/go.mod
@@ -19,6 +19,7 @@ require (
 	go.uber.org/zap v1.25.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/term v0.16.0
+	gopkg.in/yaml.v3 v3.0.1
 	moul.io/zapfilter v1.7.0
 )
 
@@ -34,7 +35,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -787,7 +787,7 @@ func (o *operation) Execute(
 		if resultWithValue, ok := core.ResultAs[core.ResultWithValue](result); ok {
 			result = core.NewResultWithOriginalSource(result.Source(), core.NewResultWithDefaultOutputOptions(resultWithValue, o.outputFlag))
 		}
-	} else if body, _ := io.ReadAll(resp.Body); len(body) == 0 && !isRawOuput {
+	} else if resp.ContentLength <= 0 && (resp.Body == nil || resp.StatusCode == http.StatusNoContent) && !isRawOuput {
 		_ = spinnerInfo.Stop()
 		logger.Debug("no output flag specified")
 		pterm.DefaultBasicText.Println(pterm.LightGreen("✅ Operation executed successfully"))


### PR DESCRIPTION
Refactor the handleResultWithReader function in cmd_result_format.go to support YAML output. This change adds the necessary code to handle YAML output formatting and unmarshaling. It also introduces a new yamlOutputFormatter struct and modifies the existing code to use it when the output format is set to yaml. This improvement enhances the flexibility of the result formatting functionality.