### PR TITLE
feat: Add function to retrieve configurations from tags

### DIFF
--- a/mgc/terraform-provider-mgc/docs/resources/virtual_machine_instances.md
+++ b/mgc/terraform-provider-mgc/docs/resources/virtual_machine_instances.md
@@ -17,35 +17,35 @@ Operations with instances, including create, delete, start, stop, reboot and oth
 
 ### Required
 
-- `image` (Attributes) (see [below for nested schema](#nestedatt--image))
-- `machine_type` (Attributes) (see [below for nested schema](#nestedatt--machine_type))
-- `name` (String)
-- `ssh_key_name` (String)
+- `image` (Attributes) The image used to create the virtual machine instance. (see [below for nested schema](#nestedatt--image))
+- `machine_type` (Attributes) The machine type of the virtual machine instance. (see [below for nested schema](#nestedatt--machine_type))
+- `name` (String) The name of the virtual machine instance.
+- `ssh_key_name` (String) The name of the SSH key associated with the virtual machine instance.
 
 ### Optional
 
-- `name_is_prefix` (Boolean)
-- `network` (Attributes) (see [below for nested schema](#nestedatt--network))
+- `name_is_prefix` (Boolean) Indicates whether the provided name is a prefix or the exact name of the virtual machine instance.
+- `network` (Attributes) The network configuration of the virtual machine instance. (see [below for nested schema](#nestedatt--network))
 
 ### Read-Only
 
-- `created_at` (String)
-- `final_name` (String)
-- `id` (String) The ID of this resource.
-- `state` (String)
-- `status` (String)
-- `updated_at` (String)
+- `created_at` (String) The timestamp when the virtual machine instance was created.
+- `final_name` (String) The final name of the virtual machine instance after applying any naming conventions or modifications.
+- `id` (String) The unique identifier of the virtual machine instance.
+- `state` (String) The current state of the virtual machine instance.
+- `status` (String) The status of the virtual machine instance.
+- `updated_at` (String) The timestamp when the virtual machine instance was last updated.
 
 <a id="nestedatt--image"></a>
 ### Nested Schema for `image`
 
 Required:
 
-- `name` (String)
+- `name` (String) The name of the image.
 
 Read-Only:
 
-- `id` (String)
+- `id` (String) The unique identifier of the image.
 
 
 <a id="nestedatt--machine_type"></a>
@@ -53,14 +53,14 @@ Read-Only:
 
 Required:
 
-- `name` (String)
+- `name` (String) The name of the machine type.
 
 Read-Only:
 
-- `disk` (Number)
-- `id` (String)
-- `ram` (Number)
-- `vcpus` (Number)
+- `disk` (Number) The disk size of the machine type.
+- `id` (String) The unique identifier of the machine type.
+- `ram` (Number) The RAM size of the machine type.
+- `vcpus` (Number) The number of virtual CPUs of the machine type.
 
 
 <a id="nestedatt--network"></a>
@@ -68,33 +68,33 @@ Read-Only:
 
 Required:
 
-- `associate_public_ip` (Boolean)
+- `associate_public_ip` (Boolean) Indicates whether to associate a public IP address with the virtual machine instance.
 
 Optional:
 
-- `delete_public_ip` (Boolean)
-- `interface` (Attributes) (see [below for nested schema](#nestedatt--network--interface))
-- `vpc` (Attributes) (see [below for nested schema](#nestedatt--network--vpc))
+- `delete_public_ip` (Boolean) Indicates whether to delete the public IP address associated with the virtual machine instance.
+- `interface` (Attributes) The network interface configuration of the virtual machine instance. (see [below for nested schema](#nestedatt--network--interface))
+- `vpc` (Attributes) The VPC (Virtual Private Cloud) associated with the virtual machine instance. (see [below for nested schema](#nestedatt--network--vpc))
 
 Read-Only:
 
-- `ipv6` (String)
-- `private_address` (String)
-- `public_address` (String)
+- `ipv6` (String) The IPv6 address of the virtual machine instance.
+- `private_address` (String) The private IP address of the virtual machine instance.
+- `public_address` (String) The public IP address of the virtual machine instance.
 
 <a id="nestedatt--network--interface"></a>
 ### Nested Schema for `network.interface`
 
 Optional:
 
-- `security_groups` (Attributes) (see [below for nested schema](#nestedatt--network--interface--security_groups))
+- `security_groups` (Attributes List) The security groups associated with the network interface. (see [below for nested schema](#nestedatt--network--interface--security_groups))
 
 <a id="nestedatt--network--interface--security_groups"></a>
 ### Nested Schema for `network.interface.security_groups`
 
 Optional:
 
-- `id` (List of String)
+- `id` (String) The unique identifier of the security group.
 
 
 
@@ -103,5 +103,5 @@ Optional:
 
 Optional:
 
-- `id` (String)
-- `name` (String)
+- `id` (String) The unique identifier of the VPC.
+- `name` (String) The name of the VPC.

--- a/mgc/terraform-provider-mgc/docs/resources/virtual_machine_snapshots.md
+++ b/mgc/terraform-provider-mgc/docs/resources/virtual_machine_snapshots.md
@@ -17,11 +17,11 @@ Operations with snapshots for instances.
 
 ### Required
 
-- `name` (String)
-- `virtual_machine_id` (String) The id of the virtual machine.
+- `name` (String) The name of the snapshot.
+- `virtual_machine_id` (String) The ID of the virtual machine.
 
 ### Read-Only
 
-- `created_at` (String)
-- `id` (String) The ID of this resource.
-- `updated_at` (String)
+- `created_at` (String) The timestamp when the snapshot was created.
+- `id` (String) The ID of the snapshot.
+- `updated_at` (String) The timestamp when the snapshot was last updated.

--- a/mgc/terraform-provider-mgc/internal/provider/config.go
+++ b/mgc/terraform-provider-mgc/internal/provider/config.go
@@ -2,10 +2,15 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+	"strings"
 
 	"magalu.cloud/core"
 	"magalu.cloud/core/config"
 )
+
+type findKey func(key string, out any) error
 
 func getConfigs(ctx context.Context, schema *core.Schema) core.Configs {
 	config := config.FromContext(ctx)
@@ -28,4 +33,74 @@ func getConfigs(ctx context.Context, schema *core.Schema) core.Configs {
 		}
 	}
 	return result
+}
+
+func GetConfigsFromTags[T any](keys findKey, s T) T {
+	envs := listJSONTags(s)
+	for _, env := range envs {
+		var value any
+		if err := keys(env, &value); err == nil {
+			if value != nil && !reflect.ValueOf(value).IsZero() {
+				err = setField(&s, env, value)
+				if err != nil {
+					fmt.Printf("Error setting field %s: %v\n", env, err)
+				}
+			}
+		}
+	}
+	return s
+}
+
+func setField(obj any, name string, value any) error {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("obj must be a pointer to a struct")
+	}
+
+	structField := v.Elem().FieldByNameFunc(func(fieldName string) bool {
+		return strings.EqualFold(fieldName, name)
+	})
+
+	if !structField.IsValid() {
+		return fmt.Errorf("no such field: %s in obj", name)
+	}
+
+	if !structField.CanSet() {
+		return fmt.Errorf("cannot set field %s in obj", name)
+	}
+
+	valueReflet := reflect.ValueOf(value)
+
+	if structField.Kind() == reflect.Ptr {
+		if valueReflet.Kind() != reflect.Ptr {
+			valPtr := reflect.New(structField.Type().Elem())
+			valPtr.Elem().Set(valueReflet.Convert(structField.Type().Elem()))
+			valueReflet = valPtr
+		}
+		structField.Set(valueReflet)
+		return nil
+	} else {
+		if !valueReflet.Type().ConvertibleTo(structField.Type()) {
+			return fmt.Errorf("cannot assign or convert value of type %s to field %s of type %s", valueReflet.Type(), name, structField.Type())
+		}
+		valueReflet = valueReflet.Convert(structField.Type())
+		structField.Set(valueReflet)
+		return nil
+	}
+}
+
+func listJSONTags(obj any) []string {
+	t := reflect.TypeOf(obj)
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+	var tags []string
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		tagValue := field.Tag.Get("json")
+		if tagValue != "" {
+			tags = append(tags, strings.Split(tagValue, ",")[0])
+		}
+	}
+	return tags
 }

--- a/mgc/terraform-provider-mgc/internal/provider/config_test.go
+++ b/mgc/terraform-provider-mgc/internal/provider/config_test.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+type TestConfig struct {
+	Name    *string `json:"name"`
+	Role    *string `json:"role"`
+	Version *int    `json:"version"`
+}
+
+type TestConfig2 struct {
+	Name    string `json:"name"`
+	Role    string `json:"role"`
+	Version int    `json:"version"`
+}
+
+func mockFindKey(key string, value any) error {
+	values := map[string]any{
+		"name":    "TestApp",
+		"role":    "TestRole",
+		"version": 1,
+		"env":     "TestEnv",
+	}
+
+	if val, ok := values[key]; ok {
+		reflect.ValueOf(value).Elem().Set(reflect.ValueOf(val))
+		return nil
+	}
+	return nil
+}
+
+func TestGetConfigsFromTags(t *testing.T) {
+	config := TestConfig{}
+
+	name := "TestApp"
+	role := "TestRole"
+	version := 1
+
+	expected := TestConfig{
+		Name:    &name,
+		Role:    &role,
+		Version: &version,
+	}
+
+	result := GetConfigsFromTags(mockFindKey, config)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestGetConfigsFromTags2(t *testing.T) {
+	config := TestConfig2{}
+
+	name := "TestApp"
+	role := "TestRole"
+	version := 1
+
+	expected := TestConfig2{
+		Name:    name,
+		Role:    role,
+		Version: version,
+	}
+
+	result := GetConfigsFromTags(mockFindKey, config)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestGetConfigsFromTagsIgnoreEmptyValues(t *testing.T) {
+	type MyTestConfig struct {
+		Banana  *string `json:"banana"`
+		Role    *string `json:"role"`
+		Version *int    `json:"version"`
+	}
+
+	config := MyTestConfig{}
+
+	role := "TestRole"
+	version := 1
+
+	expected := MyTestConfig{
+		Role:    &role,
+		Version: &version,
+	}
+
+	result := GetConfigsFromTags(mockFindKey, config)
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func TestSetField(t *testing.T) {
+	type TestStruct struct {
+		Name    string
+		Role    string
+		Version int
+	}
+
+	testStruct := TestStruct{
+		Name:    "TestApp",
+		Role:    "TestRole",
+		Version: 1,
+	}
+
+	newValue := "NewName"
+
+	err := setField(&testStruct, "Name", newValue)
+
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+
+	if testStruct.Name != newValue {
+		t.Errorf("Expected %s, got %s", newValue, testStruct.Name)
+	}
+}
+
+func TestSetField2(t *testing.T) {
+	type TestStruct struct {
+		Name    *string
+		Role    *string
+		Version *int
+	}
+
+	testStruct := TestStruct{
+		Name:    nil,
+		Role:    nil,
+		Version: nil,
+	}
+
+	newValue := "NewName"
+
+	err := setField(&testStruct, "Name", newValue)
+
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+
+	if *testStruct.Name != newValue {
+		t.Errorf("Expected %s, got %s", newValue, *testStruct.Name)
+	}
+}

--- a/mgc/terraform-provider-mgc/internal/provider/mgc_resource_vm_instances.go
+++ b/mgc/terraform-provider-mgc/internal/provider/mgc_resource_vm_instances.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
@@ -114,56 +113,68 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 		MarkdownDescription: description,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
+				Description: "The unique identifier of the virtual machine instance.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Computed: true,
 			},
 			"name_is_prefix": schema.BoolAttribute{
-				Optional: true,
-				Computed: true,
-				Default:  booldefault.StaticBool(false),
+				Description: "Indicates whether the provided name is a prefix or the exact name of the virtual machine instance.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 			},
 			"name": schema.StringAttribute{
+				Description: "The name of the virtual machine instance.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Required: true,
 			},
 			"final_name": schema.StringAttribute{
+				Description: "The final name of the virtual machine instance after applying any naming conventions or modifications.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Computed: true,
 			},
 			"updated_at": schema.StringAttribute{
-				Computed: true,
+				Description: "The timestamp when the virtual machine instance was last updated.",
+				Computed:    true,
 			},
 			"created_at": schema.StringAttribute{
+				Description: "The timestamp when the virtual machine instance was created.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Computed: true,
 			},
 			"ssh_key_name": schema.StringAttribute{
+				Description: "The name of the SSH key associated with the virtual machine instance.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Required: true,
 			},
 			"state": schema.StringAttribute{
-				Computed: true,
+				Description: "The current state of the virtual machine instance.",
+				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Computed: true,
+				Description: "The status of the virtual machine instance.",
+				Computed:    true,
 			},
 			"image": schema.SingleNestedAttribute{
-				Required: true,
+				Description: "The image used to create the virtual machine instance.",
+				Required:    true,
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
-						Computed: true,
+						Description: "The unique identifier of the image.",
+						Computed:    true,
 					},
 					"name": schema.StringAttribute{
+						Description: "The name of the image.",
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
@@ -175,25 +186,31 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"machine_type": schema.SingleNestedAttribute{
-				Required: true,
+				Description: "The machine type of the virtual machine instance.",
+				Required:    true,
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
-						Computed: true,
+						Description: "The unique identifier of the machine type.",
+						Computed:    true,
 					},
 					"name": schema.StringAttribute{
+						Description: "The name of the machine type.",
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
 						Required: true,
 					},
 					"disk": schema.NumberAttribute{
-						Computed: true,
+						Description: "The disk size of the machine type.",
+						Computed:    true,
 					},
 					"ram": schema.NumberAttribute{
-						Computed: true,
+						Description: "The RAM size of the machine type.",
+						Computed:    true,
 					},
 					"vcpus": schema.NumberAttribute{
-						Computed: true,
+						Description: "The number of virtual CPUs of the machine type.",
+						Computed:    true,
 					},
 				},
 				Validators: []validator.Object{
@@ -201,9 +218,11 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				},
 			},
 			"network": schema.SingleNestedAttribute{
-				Optional: true,
+				Description: "The network configuration of the virtual machine instance.",
+				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"delete_public_ip": schema.BoolAttribute{
+						Description: "Indicates whether to delete the public IP address associated with the virtual machine instance.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseStateForUnknown(),
 						},
@@ -212,33 +231,39 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						Computed: true,
 					},
 					"associate_public_ip": schema.BoolAttribute{
-						Required: true,
+						Description: "Indicates whether to associate a public IP address with the virtual machine instance.",
+						Required:    true,
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.RequiresReplace(),
 						},
 					},
 					"ipv6": schema.StringAttribute{
+						Description: "The IPv6 address of the virtual machine instance.",
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
 						Computed: true,
 					},
 					"private_address": schema.StringAttribute{
+						Description: "The private IP address of the virtual machine instance.",
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
 						Computed: true,
 					},
 					"public_address": schema.StringAttribute{
+						Description: "The public IP address of the virtual machine instance.",
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.UseStateForUnknown(),
 						},
 						Computed: true,
 					},
 					"vpc": schema.SingleNestedAttribute{
-						Optional: true,
+						Description: "The VPC (Virtual Private Cloud) associated with the virtual machine instance.",
+						Optional:    true,
 						Attributes: map[string]schema.Attribute{
 							"id": schema.StringAttribute{
+								Description: "The unique identifier of the VPC.",
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.UseStateForUnknown(),
 								},
@@ -246,6 +271,7 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 								Computed: true,
 							},
 							"name": schema.StringAttribute{
+								Description: "The name of the VPC.",
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.UseStateForUnknown(),
 								},
@@ -255,14 +281,18 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 						},
 					},
 					"interface": schema.SingleNestedAttribute{
-						Optional: true,
+						Description: "The network interface configuration of the virtual machine instance.",
+						Optional:    true,
 						Attributes: map[string]schema.Attribute{
-							"security_groups": schema.SingleNestedAttribute{
-								Optional: true,
-								Attributes: map[string]schema.Attribute{
-									"id": schema.ListAttribute{
-										Optional:    true,
-										ElementType: types.StringType,
+							"security_groups": schema.ListNestedAttribute{
+								Description: "The security groups associated with the network interface.",
+								Optional:    true,
+								NestedObject: schema.NestedAttributeObject{
+									Attributes: map[string]schema.Attribute{
+										"id": schema.StringAttribute{
+											Description: "The unique identifier of the security group.",
+											Optional:    true,
+										},
 									},
 								},
 							},
@@ -342,21 +372,20 @@ func (r *vmInstances) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 
 	if state.Network.Interface != nil && len(state.Network.Interface.SecurityGroups) > 0 {
-		var ids []string
+		var items []sdkVmInstances.CreateParametersNetworkInterfaceSecurityGroupsItem
 		for _, sg := range state.Network.Interface.SecurityGroups {
-			ids = append(ids, sg.ID.ValueString())
+			items = append(items, sdkVmInstances.CreateParametersNetworkInterfaceSecurityGroupsItem{
+				Id: sg.ID.ValueString(),
+			})
 		}
-
-		createParams.Network.Interface.SecurityGroups = &sdkVmInstances.CreateParametersNetworkInterfaceSecurityGroups{
-			sdkVmInstances.CreateParametersNetworkInterfaceSecurityGroupsItem{
-				Id: strings.Join(ids, ","),
-			},
-		}
+		vmInstancesNetworkInterfaceSecurityGroups := sdkVmInstances.CreateParametersNetworkInterfaceSecurityGroups(items)
+		createParams.Network.Interface = &sdkVmInstances.CreateParametersNetworkInterface{}
+		createParams.Network.Interface.SecurityGroups = &vmInstancesNetworkInterfaceSecurityGroups
 	}
 
 	createParams.Network.AssociatePublicIp = state.Network.AssociatePublicIP.ValueBoolPointer()
 
-	result, err := r.vmInstances.Create(createParams, sdkVmInstances.CreateConfigs{})
+	result, err := r.vmInstances.Create(createParams, GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmInstances.CreateConfigs{}))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating vm",
@@ -407,7 +436,7 @@ func (r *vmInstances) Update(ctx context.Context, req resource.UpdateRequest, re
 			MachineType: sdkVmInstances.RetypeParametersMachineType{
 				Id: machineType.ID.ValueString(),
 			},
-		}, sdkVmInstances.RetypeConfigs{})
+		}, GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmInstances.RetypeConfigs{}))
 
 		if err != nil {
 			resp.Diagnostics.AddError(
@@ -442,7 +471,7 @@ func (r *vmInstances) Delete(ctx context.Context, req resource.DeleteRequest, re
 			DeletePublicIp: data.Network.DeletePublicIP.ValueBoolPointer(),
 			Id:             data.ID.ValueString(),
 		},
-		sdkVmInstances.DeleteConfigs{})
+		GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmInstances.DeleteConfigs{}))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting VM",
@@ -495,7 +524,7 @@ func (r *vmInstances) setValuesFromServer(data vmInstancesResourceModel, server 
 
 func (r *vmInstances) getMachineTypeID(name string) (*vmInstancesMachineTypeModel, error) {
 	machineType := vmInstancesMachineTypeModel{}
-	machineTypeList, err := r.vmMachineTypes.List(sdkVmMachineTypes.ListParameters{}, sdkVmMachineTypes.ListConfigs{})
+	machineTypeList, err := r.vmMachineTypes.List(sdkVmMachineTypes.ListParameters{}, GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmMachineTypes.ListConfigs{}))
 	if err != nil {
 		return nil, fmt.Errorf("could not load machine-type list, unexpected error: " + err.Error())
 	}
@@ -524,7 +553,6 @@ func (r *vmInstances) getVmStatus(id string) (*sdkVmInstances.GetResult, error) 
 	duration := 5 * time.Minute
 	startTime := time.Now()
 	getParam := sdkVmInstances.GetParameters{Id: id, Expand: expand}
-	getConfigParam := sdkVmInstances.GetConfigs{}
 	var err error
 	for {
 		elapsed := time.Since(startTime)
@@ -536,7 +564,7 @@ func (r *vmInstances) getVmStatus(id string) (*sdkVmInstances.GetResult, error) 
 			return getResult, fmt.Errorf("timeout to read VM ID")
 		}
 
-		*getResult, err = r.vmInstances.Get(getParam, getConfigParam)
+		*getResult, err = r.vmInstances.Get(getParam, GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmInstances.GetConfigs{}))
 		if err != nil {
 			return getResult, err
 		}
@@ -554,7 +582,6 @@ func (r *vmInstances) checkVmIsNotFound(id string) {
 	duration := 5 * time.Minute
 	startTime := time.Now()
 	getParam := sdkVmInstances.GetParameters{Id: id}
-	getConfigParam := sdkVmInstances.GetConfigs{}
 	var err error
 	for {
 		elapsed := time.Since(startTime)
@@ -566,7 +593,7 @@ func (r *vmInstances) checkVmIsNotFound(id string) {
 			return
 		}
 
-		*getResult, err = r.vmInstances.Get(getParam, getConfigParam)
+		*getResult, err = r.vmInstances.Get(getParam, GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmInstances.GetConfigs{}))
 		if err != nil {
 			return
 		}

--- a/mgc/terraform-provider-mgc/internal/provider/mgc_resource_vm_snapshots.go
+++ b/mgc/terraform-provider-mgc/internal/provider/mgc_resource_vm_snapshots.go
@@ -71,35 +71,30 @@ func (r *vmSnapshots) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 		MarkdownDescription: description,
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-				Computed: true,
+				Description:   "The ID of the snapshot.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Computed:      true,
 			},
 			"name": schema.StringAttribute{
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-				Required: true,
+				Description:   "The name of the snapshot.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Required:      true,
 			},
 			"virtual_machine_id": schema.StringAttribute{
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-				MarkdownDescription: "The id of the virtual machine.",
+				Description:         "The ID of the virtual machine.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				MarkdownDescription: "The ID of the virtual machine.",
 				Required:            true,
 			},
 			"updated_at": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Description:   "The timestamp when the snapshot was last updated.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-				Computed: true,
+				Description:   "The timestamp when the snapshot was created.",
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+				Computed:      true,
 			},
 		},
 	}
@@ -114,7 +109,7 @@ func (r *vmSnapshots) getVmSnapshot(id string) (sdkVmSnapshots.GetResult, error)
 		sdkVmSnapshots.GetParameters{
 			Id: id,
 		},
-		sdkVmSnapshots.GetConfigs{})
+		GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmSnapshots.GetConfigs{}))
 	if err != nil {
 		return sdkVmSnapshots.GetResult{}, err
 	}
@@ -155,7 +150,7 @@ func (r *vmSnapshots) Create(ctx context.Context, req resource.CreateRequest, re
 		},
 	}
 
-	result, err := r.vmSnapshots.Create(createParams, sdkVmSnapshots.CreateConfigs{})
+	result, err := r.vmSnapshots.Create(createParams, GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmSnapshots.CreateConfigs{}))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Creating VM Snapshot",
@@ -187,7 +182,7 @@ func (r *vmSnapshots) Delete(ctx context.Context, req resource.DeleteRequest, re
 		sdkVmSnapshots.DeleteParameters{
 			Id: data.ID.ValueString(),
 		},
-		sdkVmSnapshots.DeleteConfigs{})
+		GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmSnapshots.DeleteConfigs{}))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting VM Snapshot",


### PR DESCRIPTION
This commit adds a new function `GetConfigsFromTags` to the `config.go` file. This function retrieves configurations from tags using a provided `findKey` function. It iterates through the JSON tags of a struct, calls the `findKey` function for each tag, and assigns the corresponding value to the struct field if it is not nil or zero. The function also includes helper functions `setField` and `listJSONTags` to support its implementation.

The purpose of this change is to provide a convenient way to retrieve configurations from tags, allowing for more flexible and dynamic configuration handling.