### PR TITLE
feat: add contributing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ by Terraform Plugin Provider to perform CRUD on resources.
 the SDK. The commands can either come from dynamic loaded OpenAPI spec or static
 modules, i.e: authentication.
 
+* **[terraform-provider-mgc](./mgc/terraform-provider-mgc/)**: Terraform Plugin Provider,
+with the same commands and actions defined by the SDK. The provider enables
+managing resources on Magalu Cloud.
+
 Most of our code is written in Golang, however there are some utility scripts written
 in Python as well.
 
@@ -46,7 +50,7 @@ For this, [Poetry](https://python-poetry.org/) is used. Check [Poetry.md](Poetry
 
 ## Running the CLI
 
-See [cli/RUNNING.md](./mgc/cli/RUNNING.md)
+See [cli/DEVELOPMENT.md](./mgc/cli/DEVELOPMENT.md)
 
 ## OpenAPI
 

--- a/mgc/terraform-provider-mgc/CONTRIBUTING.md
+++ b/mgc/terraform-provider-mgc/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+## Magalu Cloud Provider
+
+The MGC provider allows you to use Terraform to manage your resources on Magalu Cloud.
+
+# Development build
+
+## Dependencies and build
+
+```shell
+go mod tidy
+make build
+```
+
+## Using local provider
+
+```terraform
+terraform {
+  required_providers {
+    mgc = {
+      source  = "terraform.local/local/mgc"
+      version = "1.0.0"
+    }
+  }
+}
+```
+

--- a/mgc/terraform-provider-mgc/Makefile
+++ b/mgc/terraform-provider-mgc/Makefile
@@ -107,4 +107,10 @@ setup-config: ## Setup configuration file for Terraform or OpenTofu
 	@echo "File $$config_file written to $$HOME:"
 	@cat $$config_file
 
+build: ## Build the plugin
+	@echo "Building the plugin..."
+	@mkdir -p ~/.terraform.d/plugins/terraform.local/local/mgc/1.0.0/linux_amd64/
+	@go build -o ~/.terraform.d/plugins/terraform.local/local/mgc/1.0.0/linux_amd64/terraform-provider-mgc_v1.0.0
+	@echo "Plugin built successfully."
+
 all: update-subcategory check-example-usage check-empty-subcategory generate-docs setup-config ## Run all tasks

--- a/mgc/terraform-provider-mgc/README.md
+++ b/mgc/terraform-provider-mgc/README.md
@@ -15,7 +15,7 @@ The provider is currently under development, so new Magalu Cloud resources will 
 
 # Participate
 - You can contribute to an [open issue](https://github.com/MagaluCloud/terraform-provider-mgc/issues) to report a bug or suggest improvements and new features
-- You can open tópic in our [Dicussions Forum](https://github.com/MagaluCloud/terraform-provider-mgc/discussions)
+- You can open topic in our [Dicussions Forum](https://github.com/MagaluCloud/terraform-provider-mgc/discussions)
 - See our roadmap in [projects](https://github.com/orgs/MagaluCloud/projects/2/views/7)
 
 


### PR DESCRIPTION
Create contributing documentation for terraform-provider-mgc:

- Updates README with description of sub-directory
- Fixes broken links on README
- Creates mgc/terraform-provider-mgc/CONTRIBUTING.md
- Adds `make build` command for the terraform-provider-mgc