### PR TITLE
[tf] fix: Fix nodepools import error

### DIFF
--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_k8s_nodepool.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_k8s_nodepool.go
@@ -285,6 +285,7 @@ func (r *NewNodePoolResource) ImportState(ctx context.Context, req resource.Impo
 		return
 	}
 
+	data.ClusterID = types.StringValue(ids[0])
 	data.NodePool = tfutil.ConvertToNodePoolGet(&nodepool)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)
 }


### PR DESCRIPTION
Resolve an import error in the nodepools functionality by ensuring the ClusterID is correctly set during the import state process.