### PR TITLE
chore: update tf docs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,6 +108,7 @@ jobs:
         uses: ksivamuthu/actions-setup-gh-cli@v3  
       - name: Copy Docs
         run: |
+          rm -rf terraform-provider-mgc/docs
           cp -r mgc/terraform-provider-mgc/docs/* terraform-provider-mgc/docs/
           cp mgc/terraform-provider-mgc/README.md terraform-provider-mgc/README.md
       - name: Create Pull Request

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,7 +108,7 @@ jobs:
         uses: ksivamuthu/actions-setup-gh-cli@v3  
       - name: Copy Docs
         run: |
-          rm -rf terraform-provider-mgc/docs
+          rm -rf terraform-provider-mgc/docs/**
           cp -r mgc/terraform-provider-mgc/docs/* terraform-provider-mgc/docs/
           cp mgc/terraform-provider-mgc/README.md terraform-provider-mgc/README.md
       - name: Create Pull Request


### PR DESCRIPTION
Limpa o diretório de documentação gerada para TF toda vez que as docs forem geradas.

Isto foi feito para evitar que recursos removidos sigam com documentação e apareçam no registry do Terraform (ex.: https://registry.terraform.io/providers/MagaluCloud/mgc/latest/docs/resources/network_rules)