### PR TITLE
chore: change query-param

### DIFF
--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -408,6 +408,9 @@ func (o *operation) getRequestUrl(
 	queryValues := url.Values{}
 	path := o.key
 	_, err = o.parameters.forEachWithValue(paramValues, parametersLocations, func(externalName string, parameter *openapi3.Parameter, value any) (run bool, err error) {
+		if value == nil {
+			return true, nil
+		}
 		switch parameter.In {
 		case openapi3.ParameterInPath:
 			path = replaceInPath(path, parameter, value)


### PR DESCRIPTION
Alterado a forma que parametros do tipo `query param` são incluidos na montagem do http request.

Foi identificado que o request era enviado passando `nil` como valor do parametro. Isso só acontecia quando a spec **não** possuia valor padrão para o parametro.

O tratamento é semelhante ao aplicado no commit `11cd1b5d227411d8707e44ef33c664bcb3b129fd` .

_

Antes do ajuste:
![Screenshot From 2024-11-08 15-19-20](https://github.com/user-attachments/assets/8e885f23-8639-4747-8e3f-be42eec2116b)
![Screenshot From 2024-11-08 15-38-15](https://github.com/user-attachments/assets/95fdcc39-31c2-41cc-8a4c-1dfd89f155d3)

Após o ajuste:
![Screenshot From 2024-11-08 15-19-24](https://github.com/user-attachments/assets/4e014a16-5f37-4cfc-a5e6-57ffe52476cb)
![Screenshot From 2024-11-08 15-42-00](https://github.com/user-attachments/assets/c302a83b-36d2-434f-93e6-b2054cc57d79)
