### PR TITLE
feat: Add openapi security schema HTTPBearer

### DIFF
--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -538,6 +538,7 @@ func isSupportedScheme(schema string) bool {
 		oAuth2Method,
 		apiKeyAuthMethod,
 		xaasAuthMethod,
+		HTTPBearer,
 	}
 
 	for _, supportedScheme := range allSupportedSchemes {
@@ -557,6 +558,8 @@ const xaasAuthMethod = "xaasauth"
 const oAuth2Method = "oauth2"
 
 const bearerAuthMethod = "bearerauth"
+
+const HTTPBearer = "httpbearer"
 
 func (o *operation) setSecurityHeader(ctx context.Context, paramValues core.Parameters, req *http.Request, auth mgcAuthPkg.Authenticator) (err error) {
 	if isAuthForced(paramValues) || o.needsAuth() {


### PR DESCRIPTION
# Description

**What does this PR do?**
<!-- Provide a clear and concise description of the changes -->
Introduces the following changes:

- Adds a new security schema named `HTTPBearer` to the list of supported authentication methods (`isSupportedScheme` function).
- Defines a constant `HTTPBearer` with the value `"httpbearer"`.

These changes extend the existing OpenAPI security mechanisms by including support for HTTP Bearer authentication.

**Related Issue**
<!-- Does it fix an open issue? Link it here -->
Fixes #[issue_number]

## Type of change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup/refactoring

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes -->
- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing (please describe and provide some evidence)

## Checklist
- [x] Run Pre commit `pre-commit run --all-files`
- [x] Code follows the style guidelines of this project
- [ ] Corresponding changes to the documentation were made
- [x] No new warnings were generated
- [x] Tests that prove the fix is effective or that the feature works
- [x] Existing automated tests are passing (or have been updated to pass)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->

## Additional Notes
<!-- Add any other context about the PR here -->
