### PR TITLE
chore: update dbaas instance create terraform documentation

### DIFF
--- a/mgc/terraform-provider-mgc/docs/resources/dbaas_instances.md
+++ b/mgc/terraform-provider-mgc/docs/resources/dbaas_instances.md
@@ -14,12 +14,12 @@ Database instances management.
 
 ```terraform
 resource "mgc_dbaas_instances" "dbaas_instances" {
-  name      = "my-database-instance"
-  flavor_id = "your-flavor-id"
-  user      = "db_user"
-  password  = "secure_password123"
-
-  volume {
+  name             = "my-database-instance"
+  user             = "db_user"
+  password         = "secure_password123"
+  engine_id        = "063f3994-b6c2-4c37-96c9-bab8d82d36f7" #mysql 8.0 - please check the available version
+  instance_type_id = "c460d5c1-883d-4fea-afc3-1a208e982084" #cloud-dbaas-bs1.medium - please check the available engine
+  volume = {
     size = 50 # Size in GiB
   }
 }

--- a/mgc/terraform-provider-mgc/examples/resources/mgc_dbaas_instances/resource.tf
+++ b/mgc/terraform-provider-mgc/examples/resources/mgc_dbaas_instances/resource.tf
@@ -1,10 +1,10 @@
 resource "mgc_dbaas_instances" "dbaas_instances" {
-  name      = "my-database-instance"
-  flavor_id = "your-flavor-id"
-  user      = "db_user"
-  password  = "secure_password123"
-
-  volume {
+  name             = "my-database-instance"
+  user             = "db_user"
+  password         = "secure_password123"
+  engine_id        = "063f3994-b6c2-4c37-96c9-bab8d82d36f7" #mysql 8.0 - please check the available version
+  instance_type_id = "c460d5c1-883d-4fea-afc3-1a208e982084" #cloud-dbaas-bs1.medium - please check the available engine
+  volume = {
     size = 50 # Size in GiB
   }
 }


### PR DESCRIPTION
## What does this PR do?
This pull request includes updates to the `mgc_dbaas_instances` resource in both the documentation and example Terraform configuration files. The changes involve replacing the `flavor_id` attribute with new attributes for `engine_id` and `instance_type_id`.

Updates to `mgc_dbaas_instances` resource:

* [`mgc/terraform-provider-mgc/docs/resources/dbaas_instances.md`](diffhunk://#diff-46c0c6e76a1521b7d31d3e324b96f7da96ef16028dc225cc4a92858f607e6cccL18-R22): Removed `flavor_id` and added `engine_id` and `instance_type_id` with sample values and comments to check available versions and engines.
* [`mgc/terraform-provider-mgc/examples/resources/mgc_dbaas_instances/resource.tf`](diffhunk://#diff-946647920863685c2b672df1e08c8f4b79608221d054b1074d54d36bb777291dL3-R7): Removed `flavor_id` and added `engine_id` and `instance_type_id` with sample values and comments to check available versions and engines.

## How Has This Been Tested?
n/a
## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
