### PR TITLE
chore: adjust block volume and snapshots to validade if a field can b…

### DIFF
--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
@@ -102,6 +102,7 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 				Description: "The unique identifier of the block storage.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 				Computed: true,
 			},
@@ -131,7 +132,10 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 			},
 			"snapshot_id": schema.StringAttribute{
 				Description: "The unique identifier of the snapshot used to create the block storage.",
-				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Optional: true,
 			},
 			"availability_zones": schema.ListAttribute{
 				Description: "The availability zones where the block storage is available.",
@@ -139,7 +143,7 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 				Computed:    true,
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.List{
-					listplanmodifier.UseStateForUnknown(),
+					listplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(1),

--- a/mgc/terraform-provider-mgc/tests/block-storage/main.tf
+++ b/mgc/terraform-provider-mgc/tests/block-storage/main.tf
@@ -1,0 +1,42 @@
+resource "mgc_block_storage_volumes" "example_volume" {
+  name               = "example-volume"
+  availability_zones = ["br-ne1-a"]
+  size               = 110
+  type = {
+    name = "nvme"
+  }
+}
+
+resource "mgc_virtual_machine_instances" "basic_instance" {
+  name = "basic-instance-test-smoke"
+
+  machine_type = {
+    name = "cloud-bs1.xsmall"
+  }
+
+  image = {
+    name = "cloud-ubuntu-22.04 LTS"
+  }
+
+  network = {
+    associate_public_ip = false
+    delete_public_ip    = false
+  }
+
+  ssh_key_name = "publio"
+}
+
+resource "mgc_block_storage_volume_attachment" "example_attachment" {
+  block_storage_id   = mgc_block_storage_volumes.example_volume.id
+  virtual_machine_id = mgc_virtual_machine_instances.basic_instance.id
+}
+
+resource "mgc_block_storage_snapshots" "snapshot_example" {
+  description = "snapshot-example"
+  name        = "snapshot-example"
+  type        = "instant"
+  volume = {
+    id = mgc_block_storage_volumes.example_volume.id
+  }
+  depends_on = [mgc_block_storage_volume_attachment.example_attachment]
+}

--- a/mgc/terraform-provider-mgc/tests/block-storage/provider.tf
+++ b/mgc/terraform-provider-mgc/tests/block-storage/provider.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    mgc = {
+      source = "magalucloud/mgc"
+    }
+  }
+}
+
+provider "mgc" {
+  region  = var.region
+  api_key = var.api_key
+}
+
+variable "region" {
+  type    = string
+  default = "br-ne1"
+}
+variable "api_key" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## What does this PR do?

- Block storage volume and snapshots now validate changes to field correctly 
- Minor code smells adjusts in the resources implementations

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
All ok
  <!-- Example: Added unit tests for the new order history endpoint. All tests passed successfully. -->

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.

<details>
<summary>TF Output</summary>

```
terraform-provider-mgc/tests/block-storage on  block-storage-updates [$!+] via 💠 default on 󱒕 mgc-dev (br-ne1) took 15s
❯ tfa

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  + create

Terraform will perform the following actions:

  # mgc_block_storage_snapshots.snapshot_example will be created
  + resource "mgc_block_storage_snapshots" "snapshot_example" {
      + availability_zones = (known after apply)
      + created_at         = (known after apply)
      + description        = "snapshot-example"
      + final_name         = (known after apply)
      + id                 = (known after apply)
      + name               = "snapshot-example"
      + name_is_prefix     = false
      + size               = (known after apply)
      + state              = (known after apply)
      + status             = (known after apply)
      + type               = "instant"
      + updated_at         = (known after apply)
      + volume             = {
          + id = (known after apply)
        }
    }

  # mgc_block_storage_volume_attachment.example_attachment will be created
  + resource "mgc_block_storage_volume_attachment" "example_attachment" {
      + block_storage_id   = (known after apply)
      + virtual_machine_id = (known after apply)
    }

  # mgc_block_storage_volumes.example_volume will be created
  + resource "mgc_block_storage_volumes" "example_volume" {
      + availability_zones = [
          + "br-ne1-a",
        ]
      + created_at         = (known after apply)
      + final_name         = (known after apply)
      + id                 = (known after apply)
      + name               = "example-volume"
      + name_is_prefix     = false
      + size               = 10
      + state              = (known after apply)
      + status             = (known after apply)
      + type               = {
          + disk_type = (known after apply)
          + id        = (known after apply)
          + name      = "nvme"
          + status    = (known after apply)
        }
      + updated_at         = (known after apply)
    }

  # mgc_virtual_machine_instances.basic_instance will be created
  + resource "mgc_virtual_machine_instances" "basic_instance" {
      + created_at     = (known after apply)
      + final_name     = (known after apply)
      + id             = (known after apply)
      + image          = {
          + id   = (known after apply)
          + name = "cloud-ubuntu-22.04 LTS"
        }
      + machine_type   = {
          + disk  = (known after apply)
          + id    = (known after apply)
          + name  = "cloud-bs1.xsmall"
          + ram   = (known after apply)
          + vcpus = (known after apply)
        }
      + name           = "basic-instance-test-smoke"
      + name_is_prefix = false
      + network        = {
          + associate_public_ip = false
          + delete_public_ip    = false
          + ipv6                = (known after apply)
          + private_address     = (known after apply)
          + public_address      = (known after apply)
        }
      + ssh_key_name   = "publio"
      + state          = (known after apply)
      + status         = (known after apply)
      + updated_at     = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mgc_block_storage_volumes.example_volume: Creating...
mgc_virtual_machine_instances.basic_instance: Creating...
mgc_block_storage_volumes.example_volume: Creation complete after 9s [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Still creating... [10s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [20s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [30s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [40s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [50s elapsed]
mgc_virtual_machine_instances.basic_instance: Creation complete after 56s [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volume_attachment.example_attachment: Creating...
mgc_block_storage_volume_attachment.example_attachment: Still creating... [10s elapsed]
mgc_block_storage_volume_attachment.example_attachment: Creation complete after 12s
mgc_block_storage_snapshots.snapshot_example: Creating...
mgc_block_storage_snapshots.snapshot_example: Creation complete after 7s [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

terraform-provider-mgc/tests/block-storage on  block-storage-updates [$+] via 💠 default on 󱒕 mgc-dev (br-ne1) took 1m16s
❯ tfp
mgc_block_storage_volumes.example_volume: Refreshing state... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Refreshing state... [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volume_attachment.example_attachment: Refreshing state...
mgc_block_storage_snapshots.snapshot_example: Refreshing state... [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.

terraform-provider-mgc/tests/block-storage on  block-storage-updates [$+] via 💠 default on 󱒕 mgc-dev (br-ne1) took 3s
❯ tfp
mgc_block_storage_volumes.example_volume: Refreshing state... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Refreshing state... [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volume_attachment.example_attachment: Refreshing state...
mgc_block_storage_snapshots.snapshot_example: Refreshing state... [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # mgc_block_storage_snapshots.snapshot_example must be replaced
-/+ resource "mgc_block_storage_snapshots" "snapshot_example" {
      ~ availability_zones = [
          - "br-ne1-a",
        ] -> (known after apply)
      ~ created_at         = "Wednesday, 27-Nov-24 15:52:30 -03" -> (known after apply)
      ~ final_name         = "snapshot-example" -> (known after apply)
      ~ id                 = "5fce77be-8a5e-4d94-bba1-2ffa68210c23" -> (known after apply)
        name               = "snapshot-example"
      ~ size               = 10 -> (known after apply)
      ~ state              = "available" -> (known after apply)
      ~ status             = "completed" -> (known after apply)
      ~ updated_at         = "Wednesday, 27-Nov-24 15:52:30 -03" -> (known after apply)
      ~ volume             = {
          ~ id = "412a3975-d34d-4d3e-9831-66d270e640da" # forces replacement -> (known after apply) # forces replacement
        }
        # (3 unchanged attributes hidden)
    }

  # mgc_block_storage_volume_attachment.example_attachment will be updated in-place
  ~ resource "mgc_block_storage_volume_attachment" "example_attachment" {
      ~ block_storage_id   = "412a3975-d34d-4d3e-9831-66d270e640da" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # mgc_block_storage_volumes.example_volume must be replaced
-/+ resource "mgc_block_storage_volumes" "example_volume" {
      ~ created_at         = "2024-11-27T18:51:24Z" -> (known after apply)
      ~ final_name         = "example-volume" -> (known after apply)
      ~ id                 = "412a3975-d34d-4d3e-9831-66d270e640da" -> (known after apply)
      ~ name               = "example-volume" -> "example-volumea" # forces replacement
      ~ state              = "in-use" -> (known after apply)
      ~ status             = "completed" -> (known after apply)
      ~ type               = {
          ~ disk_type = "nvme" -> (known after apply)
          ~ id        = "cf9bdc9a-5ea1-4f2a-9478-e426ee11ff14" -> (known after apply)
            name      = "nvme"
          ~ status    = "active" -> (known after apply)
        }
      + updated_at         = (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 2 to add, 1 to change, 2 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions
if you run "terraform apply" now.

terraform-provider-mgc/tests/block-storage on  block-storage-updates [$!+] via 💠 default on 󱒕 mgc-dev (br-ne1) took 5s
❯ tfp
mgc_block_storage_volumes.example_volume: Refreshing state... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Refreshing state... [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volume_attachment.example_attachment: Refreshing state...
mgc_block_storage_snapshots.snapshot_example: Refreshing state... [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mgc_block_storage_volumes.example_volume will be updated in-place
  ~ resource "mgc_block_storage_volumes" "example_volume" {
        id                 = "412a3975-d34d-4d3e-9831-66d270e640da"
        name               = "example-volume"
      ~ size               = 10 -> 110
      ~ state              = "in-use" -> (known after apply)
      ~ status             = "completed" -> (known after apply)
      ~ type               = {
          ~ disk_type = "nvme" -> (known after apply)
          ~ id        = "cf9bdc9a-5ea1-4f2a-9478-e426ee11ff14" -> (known after apply)
            name      = "nvme"
          ~ status    = "active" -> (known after apply)
        }
      + updated_at         = (known after apply)
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions
if you run "terraform apply" now.

terraform-provider-mgc/tests/block-storage on  block-storage-updates [$!+] via 💠 default on 󱒕 mgc-dev (br-ne1) took 5s
❯ tfa
mgc_block_storage_volumes.example_volume: Refreshing state... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Refreshing state... [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volume_attachment.example_attachment: Refreshing state...
mgc_block_storage_snapshots.snapshot_example: Refreshing state... [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mgc_block_storage_volumes.example_volume will be updated in-place
  ~ resource "mgc_block_storage_volumes" "example_volume" {
        id                 = "412a3975-d34d-4d3e-9831-66d270e640da"
        name               = "example-volume"
      ~ size               = 10 -> 110
      ~ state              = "in-use" -> (known after apply)
      ~ status             = "completed" -> (known after apply)
      ~ type               = {
          ~ disk_type = "nvme" -> (known after apply)
          ~ id        = "cf9bdc9a-5ea1-4f2a-9478-e426ee11ff14" -> (known after apply)
            name      = "nvme"
          ~ status    = "active" -> (known after apply)
        }
      + updated_at         = (known after apply)
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mgc_block_storage_volumes.example_volume: Modifying... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_block_storage_volumes.example_volume: Modifications complete after 5s [id=412a3975-d34d-4d3e-9831-66d270e640da]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

terraform-provider-mgc/tests/block-storage on  block-storage-updates [$!+] via 💠 default on 󱒕 mgc-dev (br-ne1) took 15s
❯ tfp
mgc_block_storage_volumes.example_volume: Refreshing state... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Refreshing state... [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volume_attachment.example_attachment: Refreshing state...
mgc_block_storage_snapshots.snapshot_example: Refreshing state... [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes
are needed.

terraform-provider-mgc/tests/block-storage on  block-storage-updates [$!+] via 💠 default on 󱒕 mgc-dev (br-ne1) took 4s
❯ tfd
mgc_block_storage_volumes.example_volume: Refreshing state... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Refreshing state... [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volume_attachment.example_attachment: Refreshing state...
mgc_block_storage_snapshots.snapshot_example: Refreshing state... [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  - destroy

Terraform will perform the following actions:

  # mgc_block_storage_snapshots.snapshot_example will be destroyed
  - resource "mgc_block_storage_snapshots" "snapshot_example" {
      - availability_zones = [
          - "br-ne1-a",
        ] -> null
      - created_at         = "Wednesday, 27-Nov-24 15:52:30 -03" -> null
      - description        = "snapshot-example" -> null
      - final_name         = "snapshot-example" -> null
      - id                 = "5fce77be-8a5e-4d94-bba1-2ffa68210c23" -> null
      - name               = "snapshot-example" -> null
      - name_is_prefix     = false -> null
      - size               = 10 -> null
      - state              = "available" -> null
      - status             = "completed" -> null
      - type               = "instant" -> null
      - updated_at         = "Wednesday, 27-Nov-24 15:52:30 -03" -> null
      - volume             = {
          - id = "412a3975-d34d-4d3e-9831-66d270e640da" -> null
        } -> null
    }

  # mgc_block_storage_volume_attachment.example_attachment will be destroyed
  - resource "mgc_block_storage_volume_attachment" "example_attachment" {
      - block_storage_id   = "412a3975-d34d-4d3e-9831-66d270e640da" -> null
      - virtual_machine_id = "f97eab30-bc55-4aeb-854c-69bcc65eab3d" -> null
    }

  # mgc_block_storage_volumes.example_volume will be destroyed
  - resource "mgc_block_storage_volumes" "example_volume" {
      - availability_zones = [
          - "br-ne1-a",
        ] -> null
      - created_at         = "2024-11-27T18:51:24Z" -> null
      - final_name         = "example-volume" -> null
      - id                 = "412a3975-d34d-4d3e-9831-66d270e640da" -> null
      - name               = "example-volume" -> null
      - name_is_prefix     = false -> null
      - size               = 110 -> null
      - state              = "in-use" -> null
      - status             = "completed" -> null
      - type               = {
          - disk_type = "nvme" -> null
          - id        = "cf9bdc9a-5ea1-4f2a-9478-e426ee11ff14" -> null
          - name      = "nvme" -> null
          - status    = "active" -> null
        } -> null
    }

  # mgc_virtual_machine_instances.basic_instance will be destroyed
  - resource "mgc_virtual_machine_instances" "basic_instance" {
      - created_at     = "Wednesday, 27-Nov-24 15:52:17 -03" -> null
      - final_name     = "basic-instance-test-smoke" -> null
      - id             = "f97eab30-bc55-4aeb-854c-69bcc65eab3d" -> null
      - image          = {
          - id   = "f47900e1-7ece-40bb-af2c-73eb03806a1e" -> null
          - name = "cloud-ubuntu-22.04 LTS" -> null
        } -> null
      - machine_type   = {
          - disk  = 10 -> null
          - id    = "45d57c50-61d3-46fc-992e-77f5605dd561" -> null
          - name  = "cloud-bs1.xsmall" -> null
          - ram   = 1024 -> null
          - vcpus = 1 -> null
        } -> null
      - name           = "basic-instance-test-smoke" -> null
      - name_is_prefix = false -> null
      - network        = {
          - associate_public_ip = false -> null
          - delete_public_ip    = false -> null
          - ipv6                = "2801:80:3ea1:cea4::1d3" -> null
          - private_address     = "172.30.1.164" -> null
          - public_address      = "" -> null
        } -> null
      - ssh_key_name   = "publio" -> null
      - state          = "running" -> null
      - status         = "completed" -> null
      - updated_at     = "Wednesday, 27-Nov-24 15:52:17 -03" -> null
    }

Plan: 0 to add, 0 to change, 4 to destroy.

Do you really want to destroy all resources?
  Terraform will destroy all your managed infrastructure, as shown above.
  There is no undo. Only 'yes' will be accepted to confirm.

  Enter a value: yes

mgc_block_storage_snapshots.snapshot_example: Destroying... [id=5fce77be-8a5e-4d94-bba1-2ffa68210c23]
mgc_block_storage_snapshots.snapshot_example: Destruction complete after 2s
mgc_block_storage_volume_attachment.example_attachment: Destroying...
mgc_block_storage_volume_attachment.example_attachment: Still destroying... [10s elapsed]
mgc_block_storage_volume_attachment.example_attachment: Destruction complete after 11s
mgc_block_storage_volumes.example_volume: Destroying... [id=412a3975-d34d-4d3e-9831-66d270e640da]
mgc_virtual_machine_instances.basic_instance: Destroying... [id=f97eab30-bc55-4aeb-854c-69bcc65eab3d]
mgc_block_storage_volumes.example_volume: Destruction complete after 2s
mgc_virtual_machine_instances.basic_instance: Destruction complete after 8s

Destroy complete! Resources: 4 destroyed.

``` 
</details>

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->