### PR TITLE
fix: removing plan modifiers from terraform fields with UseStateForUnkown that are dynamic

### DIFF
--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_snapshots.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_snapshots.go
@@ -123,7 +123,7 @@ func (r *bsSnapshots) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"final_name": schema.StringAttribute{
 				Description: "The final name of the volume snapshot after applying any naming conventions or modifications.",
-				Computed: true,
+				Computed:    true,
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "The timestamp when the block storage was last updated.",

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_snapshots.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_snapshots.go
@@ -123,9 +123,6 @@ func (r *bsSnapshots) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"final_name": schema.StringAttribute{
 				Description: "The final name of the volume snapshot after applying any naming conventions or modifications.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 				Computed: true,
 			},
 			"updated_at": schema.StringAttribute{

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
@@ -118,16 +118,12 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 			"name": schema.StringAttribute{
 				Description: "The name of the block storage.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),
 				},
 				Required: true,
 			},
 			"final_name": schema.StringAttribute{
 				Description: "The final name of the block storage after applying any naming conventions or modifications.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 				Computed: true,
 			},
 			"snapshot_id": schema.StringAttribute{

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
@@ -124,7 +124,7 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 			},
 			"final_name": schema.StringAttribute{
 				Description: "The final name of the block storage after applying any naming conventions or modifications.",
-				Computed: true,
+				Computed:    true,
 			},
 			"snapshot_id": schema.StringAttribute{
 				Description: "The unique identifier of the snapshot used to create the block storage.",

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_instances.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_instances.go
@@ -139,9 +139,6 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"final_name": schema.StringAttribute{
 				Description: "The final name of the virtual machine instance after applying any naming conventions or modifications.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 				Computed: true,
 			},
 			"updated_at": schema.StringAttribute{
@@ -221,9 +218,6 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					},
 					"name": schema.StringAttribute{
 						Description: "The name of the machine type.",
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.UseStateForUnknown(),
-						},
 						Required: true,
 					},
 					"disk": schema.NumberAttribute{

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_instances.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_instances.go
@@ -139,7 +139,7 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			},
 			"final_name": schema.StringAttribute{
 				Description: "The final name of the virtual machine instance after applying any naming conventions or modifications.",
-				Computed: true,
+				Computed:    true,
 			},
 			"updated_at": schema.StringAttribute{
 				Description: "The timestamp when the virtual machine instance was last updated.",
@@ -218,7 +218,7 @@ func (r *vmInstances) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					},
 					"name": schema.StringAttribute{
 						Description: "The name of the machine type.",
-						Required: true,
+						Required:    true,
 					},
 					"disk": schema.NumberAttribute{
 						Description: "The disk size of the machine type.",

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_snapshots.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_snapshots.go
@@ -85,8 +85,8 @@ func (r *vmSnapshots) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Required:            true,
 			},
 			"updated_at": schema.StringAttribute{
-				Description:   "The timestamp when the snapshot was last updated.",
-				Computed:      true,
+				Description: "The timestamp when the snapshot was last updated.",
+				Computed:    true,
 			},
 			"created_at": schema.StringAttribute{
 				Description:   "The timestamp when the snapshot was created.",

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_snapshots.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_snapshots.go
@@ -87,7 +87,6 @@ func (r *vmSnapshots) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			"updated_at": schema.StringAttribute{
 				Description:   "The timestamp when the snapshot was last updated.",
 				Computed:      true,
-				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"created_at": schema.StringAttribute{
 				Description:   "The timestamp when the snapshot was created.",


### PR DESCRIPTION
## What does this PR do?
 - removing plan modifiers from terraform fields with UseStateForUnkown that are dynamic
 - Fix the error message when renaming a vm or any other resource that were using the UseStateForUnkown

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
ok

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
```shell
❯ tfa -auto-approve
data.mgc_virtual_machine_types.available_types: Reading...
data.mgc_virtual_machine_images.available_images: Reading...
data.mgc_virtual_machine_instances.all_instances: Reading...
mgc_virtual_machine_instances.tc1_basic_instance: Refreshing state... [id=43a05476-e461-449c-b79b-ac9e16823fcd]
data.mgc_virtual_machine_images.available_images: Read complete after 2s
mgc_virtual_machine_instances.tc2_instance_with_az: Refreshing state... [id=4a014334-48a8-412c-91e2-d78a2ddb3b5b]
data.mgc_virtual_machine_instances.all_instances: Read complete after 5s
data.mgc_virtual_machine_types.available_types: Read complete after 7s
data.mgc_virtual_machine_instance.tc2_validation: Reading...
data.mgc_virtual_machine_instance.tc2_validation: Read complete after 1s [id=4a014334-48a8-412c-91e2-d78a2ddb3b5b]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated
with the following symbols:
  ~ update in-place
 <= read (data resources)

Terraform will perform the following actions:

  # data.mgc_virtual_machine_instance.tc1_validation will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "mgc_virtual_machine_instance" "tc1_validation" {
      + availability_zone = (known after apply)
      + id                = "43a05476-e461-449c-b79b-ac9e16823fcd"
      + image_id          = (known after apply)
      + machine_type_id   = (known after apply)
      + name              = (known after apply)
      + private_ipv4      = (known after apply)
      + public_ipv4       = (known after apply)
      + public_ipv6       = (known after apply)
      + ssh_key_name      = (known after apply)
      + state             = (known after apply)
      + status            = (known after apply)
      + user_data         = (known after apply)
    }

  # mgc_virtual_machine_instances.tc1_basic_instance will be updated in-place
  ~ resource "mgc_virtual_machine_instances" "tc1_basic_instance" {
      ~ final_name        = "tc1-basic-instance-name" -> (known after apply)
        id                = "43a05476-e461-449c-b79b-ac9e16823fcd"
      ~ image             = {
          ~ id   = "f47900e1-7ece-40bb-af2c-73eb03806a1e" -> (known after apply)
            name = "cloud-ubuntu-22.04 LTS"
        }
      ~ machine_type      = {
          ~ disk  = 40 -> (known after apply)
          ~ id    = "c6681507-befc-4c74-b1f9-64b67683ffe6" -> (known after apply)
            name  = "BV1-1-40"
          ~ ram   = 1024 -> (known after apply)
          ~ vcpus = 1 -> (known after apply)
        }
      ~ name              = "tc1-basic-instance-name" -> "tc1-basic-instance-name-new-name"
      ~ state             = "running" -> (known after apply)
      ~ status            = "completed" -> (known after apply)
      ~ updated_at        = "2024-12-02T17:04:49Z" -> (known after apply)
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ test_case_1_validation = {
      ~ az            = "br-ne1-a" -> (known after apply)
      ~ instace_type  = "c6681507-befc-4c74-b1f9-64b67683ffe6" -> (known after apply)
      ~ instance_name = "tc1-basic-instance-name" -> (known after apply)
      ~ status        = "completed" -> (known after apply)
        # (1 unchanged attribute hidden)
    }
mgc_virtual_machine_instances.tc1_basic_instance: Modifying... [id=43a05476-e461-449c-b79b-ac9e16823fcd]
mgc_virtual_machine_instances.tc1_basic_instance: Modifications complete after 6s [id=43a05476-e461-449c-b79b-ac9e16823fcd]
data.mgc_virtual_machine_instance.tc1_validation: Reading...
data.mgc_virtual_machine_instance.tc1_validation: Read complete after 1s [id=43a05476-e461-449c-b79b-ac9e16823fcd]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

test_case_1_validation = {
  "az" = "br-ne1-a"
  "instace_type" = "c6681507-befc-4c74-b1f9-64b67683ffe6"
  "instance_id" = "43a05476-e461-449c-b79b-ac9e16823fcd"
  "instance_name" = "tc1-basic-instance-name-new-name"
  "status" = "completed"
}
test_case_2_validation = {
  "az" = "br-ne1-a"
  "instance_id" = "4a014334-48a8-412c-91e2-d78a2ddb3b5b"
  "instance_name" = "tc2-instance-with-az-aa"
  "instance_type" = "458c4dc0-73a1-4952-a68f-e013792991d8"
  "status" = "completed"
}
```

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->