### PR TITLE
chore: remove public read permissions step from upload-docs workflow

### DIFF
--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -1,9 +1,7 @@
 name: Upload Docs to bucket
 
 on:
-    release:
-        types:
-            - created
+  workflow_dispatch:
 
 jobs:
     upload-docs:

--- a/.github/workflows/upload-docs.yaml
+++ b/.github/workflows/upload-docs.yaml
@@ -22,9 +22,4 @@ jobs:
           - name: Upload docs
             run: |
              mgc object objects sync ./mgc/cli/docs s3://magalucloud-docs --delete
-          - name: Set Public Read Permissions
-            run: |
-              mgc object objects list magalucloud-docs --recursive -o json --raw | jq -r '.Contents[].Key' | while read -r key; do
-                mgc object objects acl set --public-read magalucloud-docs/"$key"
-                echo "Set public-read ACL for $key"
-              done
+             


### PR DESCRIPTION
## What does this PR do?
chore: remove public read permissions step from upload-docs workflow