### PR TITLE
fix: delete objects to use single delete

### DIFF
--- a/mgc/sdk/static/object_storage/common/delete.go
+++ b/mgc/sdk/static/object_storage/common/delete.go
@@ -64,6 +64,49 @@ type deleteBatchRequestBody struct {
 	Objects []objectIdentifier `xml:"Object"`
 }
 
+
+func DeleteSingle(ctx context.Context, params DeleteObjectParams, cfg Config) error {
+    objectKey := params.Destination.AsFilePath().String()
+    versionID := params.Version
+
+    req, err := newDeleteSingleRequest(ctx, cfg, NewBucketNameFromURI(params.Destination), objectKey, versionID)
+    if err != nil {
+        return err
+    }
+
+    resp, err := SendRequest(ctx, req)
+    if err != nil {
+        return err
+    }
+
+    err = ExtractErr(resp, req)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}
+
+func newDeleteSingleRequest(ctx context.Context, cfg Config, bucketName BucketName, objectKey string, versionID string) (*http.Request, error) {
+    host, err := BuildBucketHost(cfg, bucketName)
+    if err != nil {
+        return nil, core.UsageError{Err: err}
+    }
+
+    url := fmt.Sprintf("%s/%s", host, objectKey)
+
+    if versionID != "" {
+        url = fmt.Sprintf("%s?versionId=%s", url, versionID)
+    }
+
+    req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+    if err != nil {
+        return nil, err
+    }
+
+    return req, nil
+}
+
 func newDeleteBatchRequest(ctx context.Context, cfg Config, bucketName BucketName, objKeys []objectIdentifier) (*http.Request, error) {
 	host, err := BuildBucketHost(cfg, bucketName)
 	if err != nil {
@@ -199,25 +242,32 @@ func DeleteBucket(ctx context.Context, params DeleteBucketParams, cfg Config) er
 	return ExtractErr(resp, req)
 }
 
-func Delete(ctx context.Context, params DeleteObjectParams, cfg Config) (err error) {
-	objKeys := []objectIdentifier{{Key: params.Destination.AsFilePath().String(), VersionId: params.Version}}
+func Delete(ctx context.Context, params DeleteObjectParams, cfg Config) error {
+    objKeys := []objectIdentifier{{Key: params.Destination.AsFilePath().String(), VersionId: params.Version}}
 
-	req, err := newDeleteBatchRequest(ctx, cfg, NewBucketNameFromURI(params.Destination), objKeys)
-	if err != nil {
-		return
-	}
+    if len(objKeys) > 1 {
+        req, err := newDeleteBatchRequest(ctx, cfg, NewBucketNameFromURI(params.Destination), objKeys)
+        if err != nil {
+            return err
+        }
 
-	resp, err := SendRequest(ctx, req)
-	if err != nil {
-		return err
-	}
+        resp, err := SendRequest(ctx, req)
+        if err != nil {
+            return err
+        }
 
-	err = ExtractErr(resp, req)
-	if err != nil {
-		return err
-	}
+        err = ExtractErr(resp, req)
+        if err != nil {
+            return err
+        }
+    } else {
+        err := DeleteSingle(ctx, params, cfg)
+        if err != nil {
+            return err
+        }
+    }
 
-	return nil
+    return nil
 }
 
 func DeleteObjects(ctx context.Context, params DeleteObjectsParams, cfg Config) error {


### PR DESCRIPTION
## What does this PR do?
Change the delete object so that when there is more than 1 file, do a post/batch delete and when there is only 1 file, do a delete

## How Has This Been Tested?
Manually tested sending unique file and list of files.

## Checklist
- [ ] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->