### PR TITLE
fix escape on create bucket

### DIFF
--- a/mgc/sdk/static/object_storage/common/session.go
+++ b/mgc/sdk/static/object_storage/common/session.go
@@ -56,7 +56,8 @@ func BuildHostURL(cfg Config) (*url.URL, error) {
 
 func BuildBucketHost(cfg Config, bucketName BucketName) (BucketHostString, error) {
 	simpleHost := BuildHost(cfg)
-	host, err := url.JoinPath(string(simpleHost), bucketName.String())
+	escapedBucketName := url.PathEscape(bucketName.String())
+	host, err := url.JoinPath(string(simpleHost), escapedBucketName)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What does this PR do?
Escape the "%" symbol 

## How Has This Been Tested?
Manually tested by trying to create a bucket with the name "foo%bar" and exhaustively in [s3-tester](https://github.com/marmotitude/s3-tester)

## Checklist
- [ ] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
Before
`Error: (unknown) 404 Not Found`
After
`Error: (InvalidBucketName) 400 Bad Request - The specified bucket is not valid.`