### PR TITLE
chore: change mgc auth api key create

### DIFF
--- a/mgc/sdk/go.mod
+++ b/mgc/sdk/go.mod
@@ -3,7 +3,6 @@ module magalu.cloud/sdk
 go 1.23.0
 
 require (
-	github.com/PaesslerAG/gval v1.2.2
 	github.com/geffersonFerraz/brazilian-words-sorter v1.1.0
 	github.com/getkin/kin-openapi v0.118.0
 	github.com/go-openapi/jsonpointer v0.20.0
@@ -21,6 +20,7 @@ require (
 )
 
 require (
+	github.com/PaesslerAG/gval v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
@@ -65,7 +65,7 @@ require (
 	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace magalu.cloud/core => ../core

--- a/mgc/sdk/static/auth/api_key/create.go
+++ b/mgc/sdk/static/auth/api_key/create.go
@@ -59,7 +59,7 @@ var getCreate = utils.NewLazyLoader[core.Executor](func() core.Executor {
 	})
 })
 
-func create(ctx context.Context, parameter createParams, _ struct{}) (*apiKeyResult, error) {
+func create(ctx context.Context, parameter createParams, _ struct{}) (*getApiKeyResult, error) {
 	auth := mgcAuthPkg.FromContext(ctx)
 	if auth == nil {
 		return nil, fmt.Errorf("programming error: unable to retrieve auth configuration from context")
@@ -169,5 +169,10 @@ func create(ctx context.Context, parameter createParams, _ struct{}) (*apiKeyRes
 		return nil, err
 	}
 
-	return &result, nil
+	res, err := get(ctx, getKeyParams{UUID: result.UUID}, struct{}{})
+	if err != nil {
+		return nil, fmt.Errorf("api-key created successfully.\nID: %s", result.UUID)
+	}
+
+	return &res, nil
 }

--- a/mgc/sdk/static/object_storage/common/delete.go
+++ b/mgc/sdk/static/object_storage/common/delete.go
@@ -64,47 +64,46 @@ type deleteBatchRequestBody struct {
 	Objects []objectIdentifier `xml:"Object"`
 }
 
-
 func DeleteSingle(ctx context.Context, params DeleteObjectParams, cfg Config) error {
-    objectKey := params.Destination.AsFilePath().String()
-    versionID := params.Version
+	objectKey := params.Destination.AsFilePath().String()
+	versionID := params.Version
 
-    req, err := newDeleteSingleRequest(ctx, cfg, NewBucketNameFromURI(params.Destination), objectKey, versionID)
-    if err != nil {
-        return err
-    }
+	req, err := newDeleteSingleRequest(ctx, cfg, NewBucketNameFromURI(params.Destination), objectKey, versionID)
+	if err != nil {
+		return err
+	}
 
-    resp, err := SendRequest(ctx, req)
-    if err != nil {
-        return err
-    }
+	resp, err := SendRequest(ctx, req)
+	if err != nil {
+		return err
+	}
 
-    err = ExtractErr(resp, req)
-    if err != nil {
-        return err
-    }
+	err = ExtractErr(resp, req)
+	if err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }
 
 func newDeleteSingleRequest(ctx context.Context, cfg Config, bucketName BucketName, objectKey string, versionID string) (*http.Request, error) {
-    host, err := BuildBucketHost(cfg, bucketName)
-    if err != nil {
-        return nil, core.UsageError{Err: err}
-    }
+	host, err := BuildBucketHost(cfg, bucketName)
+	if err != nil {
+		return nil, core.UsageError{Err: err}
+	}
 
-    url := fmt.Sprintf("%s/%s", host, objectKey)
+	url := fmt.Sprintf("%s/%s", host, objectKey)
 
-    if versionID != "" {
-        url = fmt.Sprintf("%s?versionId=%s", url, versionID)
-    }
+	if versionID != "" {
+		url = fmt.Sprintf("%s?versionId=%s", url, versionID)
+	}
 
-    req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
-    if err != nil {
-        return nil, err
-    }
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return nil, err
+	}
 
-    return req, nil
+	return req, nil
 }
 
 func newDeleteBatchRequest(ctx context.Context, cfg Config, bucketName BucketName, objKeys []objectIdentifier) (*http.Request, error) {
@@ -243,31 +242,31 @@ func DeleteBucket(ctx context.Context, params DeleteBucketParams, cfg Config) er
 }
 
 func Delete(ctx context.Context, params DeleteObjectParams, cfg Config) error {
-    objKeys := []objectIdentifier{{Key: params.Destination.AsFilePath().String(), VersionId: params.Version}}
+	objKeys := []objectIdentifier{{Key: params.Destination.AsFilePath().String(), VersionId: params.Version}}
 
-    if len(objKeys) > 1 {
-        req, err := newDeleteBatchRequest(ctx, cfg, NewBucketNameFromURI(params.Destination), objKeys)
-        if err != nil {
-            return err
-        }
+	if len(objKeys) > 1 {
+		req, err := newDeleteBatchRequest(ctx, cfg, NewBucketNameFromURI(params.Destination), objKeys)
+		if err != nil {
+			return err
+		}
 
-        resp, err := SendRequest(ctx, req)
-        if err != nil {
-            return err
-        }
+		resp, err := SendRequest(ctx, req)
+		if err != nil {
+			return err
+		}
 
-        err = ExtractErr(resp, req)
-        if err != nil {
-            return err
-        }
-    } else {
-        err := DeleteSingle(ctx, params, cfg)
-        if err != nil {
-            return err
-        }
-    }
+		err = ExtractErr(resp, req)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := DeleteSingle(ctx, params, cfg)
+		if err != nil {
+			return err
+		}
+	}
 
-    return nil
+	return nil
 }
 
 func DeleteObjects(ctx context.Context, params DeleteObjectsParams, cfg Config) error {


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
<!--Example: This PR adds a new endpoint to the API that allows users to retrieve their order history. It includes the necessary changes to the controller, service, and repository layers, as well as updates to the API documentation. -->
This PR modifies the output of the mgc auth api-key create command, which previously only returned the UUID of the created API key, requiring an additional execution of mgc auth api-key get UUID to retrieve the values.
Now, the values will be displayed immediately after the creation.

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
  <!-- Example: Added unit tests for the new order history endpoint. All tests passed successfully. -->

- **Integration Tests**: Detail the integration tests performed and their results.
  <!-- Example: Performed integration tests with the payment service to ensure end-to-end functionality. All tests passed. -->

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
  <!-- Example: Manually tested the new endpoint using Postman. Verified that the correct order history is returned for different users. Attached screenshots of the Postman results. -->

## Checklist
- [ ] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
![Screenshot From 2025-01-07 14-39-18](https://github.com/user-attachments/assets/332ff219-4ef7-4fdf-917d-f7cb9bed5cc8)
