### PR TITLE
feat: add encryption support for block storage volumes

### DIFF
--- a/mgc/cli/docs/block-storage/snapshots/copy/help.md
+++ b/mgc/cli/docs/block-storage/snapshots/copy/help.md
@@ -21,7 +21,7 @@
 ```bash
 Flags:
       --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
-      --destination-region string     Destination Region (required)
+      --destination-region enum       Regions (one of "br-mgl1", "br-ne1" or "br-se1") (required)
   -h, --help                          help for copy
       --id uuid                       Id (required)
   -v, --version                       version for copy

--- a/mgc/lib/go.mod
+++ b/mgc/lib/go.mod
@@ -5,8 +5,8 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
-	magalu.cloud/core v0.31.0
-	magalu.cloud/sdk v0.31.0
+	magalu.cloud/core v0.32.0
+	magalu.cloud/sdk v0.32.0
 )
 
 require (

--- a/mgc/lib/products/block_storage/volume_types/list.go
+++ b/mgc/lib/products/block_storage/volume_types/list.go
@@ -44,6 +44,7 @@ type ListResult struct {
 }
 
 type ListResultTypesItem struct {
+	AllowsEncryption  *bool                                `json:"allows_encryption,omitempty"`
 	AvailabilityZones ListResultTypesItemAvailabilityZones `json:"availability_zones"`
 	DiskType          string                               `json:"disk_type"`
 	Id                string                               `json:"id"`

--- a/mgc/lib/products/block_storage/volumes/create.go
+++ b/mgc/lib/products/block_storage/volumes/create.go
@@ -39,6 +39,7 @@ import (
 
 type CreateParameters struct {
 	AvailabilityZone *string                   `json:"availability_zone,omitempty"`
+	Encrypted        *bool                     `json:"encrypted,omitempty"`
 	Name             string                    `json:"name"`
 	Size             int                       `json:"size"`
 	Snapshot         *CreateParametersSnapshot `json:"snapshot,omitempty"`

--- a/mgc/lib/products/block_storage/volumes/get.go
+++ b/mgc/lib/products/block_storage/volumes/get.go
@@ -47,6 +47,7 @@ type GetResult struct {
 	AvailabilityZone  string                     `json:"availability_zone"`
 	AvailabilityZones GetResultAvailabilityZones `json:"availability_zones"`
 	CreatedAt         string                     `json:"created_at"`
+	Encrypted         *bool                      `json:"encrypted,omitempty"`
 	Error             *GetResultError            `json:"error,omitempty"`
 	Id                string                     `json:"id"`
 	Name              string                     `json:"name"`

--- a/mgc/lib/products/block_storage/volumes/list.go
+++ b/mgc/lib/products/block_storage/volumes/list.go
@@ -50,6 +50,7 @@ type ListResultVolumesItem struct {
 	AvailabilityZone  string                                 `json:"availability_zone"`
 	AvailabilityZones ListResultVolumesItemAvailabilityZones `json:"availability_zones"`
 	CreatedAt         string                                 `json:"created_at"`
+	Encrypted         *bool                                  `json:"encrypted,omitempty"`
 	Error             *ListResultVolumesItemError            `json:"error,omitempty"`
 	Id                string                                 `json:"id"`
 	Name              string                                 `json:"name"`

--- a/mgc/lib/products/doc.go
+++ b/mgc/lib/products/doc.go
@@ -5,7 +5,7 @@ Package: products
 
 All MagaLu Groups & Executors
 
-Version: v0.31.0
+Version: v0.32.0
 
 import "magalu.cloud/lib/products"
 */

--- a/mgc/sdk/openapi/openapis/block-storage.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/block-storage.openapi.yaml
@@ -134,402 +134,6 @@ paths:
             security:
             -   OAuth2:
                 - block-storage.write
-    /v1/backups:
-        get:
-            tags:
-            - backups
-            summary: List all backups.
-            description: "Retrieve a list of Backups for the currently authenticated\
-                \ tenant.\n\n#### Notes\n- Use the **expand** argument to obtain additional\
-                \ details about the\n Volume used to create each Backup."
-            operationId: list_backups_v1_backups_get
-            parameters:
-            -   name: expand
-                in: query
-                required: false
-                schema:
-                    type: array
-                    items:
-                        type: string
-                        title: ExpandBackup
-                        enum:
-                        - volume
-                    title: Expand
-                    default: []
-            -   name: _limit
-                in: query
-                required: false
-                schema:
-                    exclusiveMinimum: false
-                    type: integer
-                    title: ' Limit'
-                    default: 50
-            -   name: _offset
-                in: query
-                required: false
-                schema:
-                    type: integer
-                    title: ' Offset'
-                    default: 0
-            -   name: _sort
-                in: query
-                required: false
-                schema:
-                    type: string
-                    title: ' Sort'
-                    pattern: ^(^[\w-]+:(asc|desc)(,[\w-]+:(asc|desc))*)?$
-                    default: created_at:asc
-            -   name: name
-                in: query
-                required: false
-                schema:
-                    anyOf:
-                    -   type: string
-                    title: Name
-                    nullable: true
-            responses:
-                '200':
-                    description: Successful Response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/BackupListResponse'
-                '404':
-                    description: Not Found
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 404 List Backups V1 Backups Get
-                '409':
-                    description: Conflict
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 409 List Backups V1 Backups Get
-                '422':
-                    description: Unprocessable Entity
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 422 List Backups V1 Backups Get
-            x-viveiro: true
-            x-mgc-hidden: true
-            security:
-            -   OAuth2:
-                - block-storage.read
-        post:
-            tags:
-            - backups
-            summary: Create a backup.
-            description: "Create a backup for the currently authenticated tenant.\n\
-                \nThe Backup can be used when it reaches the \"available\" state and\
-                \ the\n \"completed\" status.\n\n#### Rules\n- The Backup name must\
-                \ be unique; otherwise, the creation will be disallowed.\n- The Volume\
-                \ can be either in in-use or available states.\n- The Volume must\
-                \ not have an operation in execution.\n\n#### Notes\n- Use the **block-storage\
-                \ volume list** command to retrieve a list of all\n Volumes and obtain\
-                \ the ID of the Volume that will be used to create the\n Backup."
-            operationId: create_backup_v1_backups_post
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/CreateBackup'
-                required: true
-            responses:
-                '202':
-                    description: Successful Response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/IdResponse'
-                '404':
-                    description: Not Found
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 404 Create Backup V1 Backups Post
-                '409':
-                    description: Conflict
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 409 Create Backup V1 Backups Post
-                '422':
-                    description: Unprocessable Entity
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 422 Create Backup V1 Backups Post
-            x-viveiro: true
-            x-mgc-hidden: true
-            security:
-            -   OAuth2:
-                - block-storage.write
-    /v1/backups/copy:
-        post:
-            tags:
-            - backups
-            summary: Copy backup cross region.
-            description: "Copy a backup cross region for the currently authenticated\
-                \ tenant.\n\n#### Rules\n- The copy only be accepted when the destiny\
-                \ region is different from origin region.\n- The copy only be accepted\
-                \ if the backup's name in destiny region is different from input name.\n\
-                - The copy only be accepted if the user has access to destiny region.\n\
-                \n#### Notes\n- Utilize the **block-storage backups list** command\
-                \ to retrieve a list of\n all Backups and obtain the ID of the Backup\
-                \ you wish to copy across different region."
-            operationId: copy_backup_cross_region_v1_backups_copy_post
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/CopyBackupCrossRegionRequest'
-                required: true
-            responses:
-                '204':
-                    description: Successful Response
-                '404':
-                    description: Not Found
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 404 Copy Backup Cross Region V1 Backups
-                                    Copy Post
-                '409':
-                    description: Conflict
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 409 Copy Backup Cross Region V1 Backups
-                                    Copy Post
-                '422':
-                    description: Unprocessable Entity
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 422 Copy Backup Cross Region V1 Backups
-                                    Copy Post
-            x-viveiro: true
-            x-mgc-hidden: true
-            security:
-            -   OAuth2:
-                - block-storage.write
-    /v1/backups/{id}:
-        get:
-            tags:
-            - backups
-            summary: Retrieve the details of a specific backup.
-            description: "Retrieve details of a Backup for the currently authenticated\
-                \ tenant.\n\n#### Notes\n- Use the **expand** argument to obtain additional\
-                \ details about the Volume\n used to create the Backup.\n- Utilize\
-                \ the **block-storage backups list** command to retrieve a list of\n\
-                \ all Backups and obtain the ID of the Backup for which you want to\
-                \ retrieve\n details."
-            operationId: get_backup_v1_backups__id__get
-            parameters:
-            -   name: id
-                in: path
-                required: true
-                schema:
-                    type: string
-                    title: Id
-                    format: uuid
-            -   name: expand
-                in: query
-                required: false
-                schema:
-                    type: array
-                    items:
-                        type: string
-                        title: ExpandBackup
-                        enum:
-                        - volume
-                    title: Expand
-                    default: []
-            responses:
-                '200':
-                    description: Successful Response
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/BackupResponse'
-                '404':
-                    description: Not Found
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 404 Get Backup V1 Backups  Id  Get
-                '409':
-                    description: Conflict
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 409 Get Backup V1 Backups  Id  Get
-                '422':
-                    description: Unprocessable Entity
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 422 Get Backup V1 Backups  Id  Get
-            x-viveiro: true
-            x-mgc-hidden: true
-            security:
-            -   OAuth2:
-                - block-storage.read
-        delete:
-            tags:
-            - backups
-            summary: Delete a backup.
-            description: "Delete a Backup for the currently authenticated tenant.\n\
-                \n#### Rules\n- The Backup's status must be \"completed\".\n- The\
-                \ Backup's state must be \"available\".\n\n\n#### Notes\n- Utilize\
-                \ the **block-storage backups** list command to retrieve a list of\n\
-                \ all Backups and obtain the ID of the Backup you wish to delete."
-            operationId: delete_backup_v1_backups__id__delete
-            parameters:
-            -   name: id
-                in: path
-                required: true
-                schema:
-                    type: string
-                    title: Id
-                    format: uuid
-            responses:
-                '204':
-                    description: Successful Response
-                '404':
-                    description: Not Found
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 404 Delete Backup V1 Backups  Id  Delete
-                '409':
-                    description: Conflict
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 409 Delete Backup V1 Backups  Id  Delete
-                '422':
-                    description: Unprocessable Entity
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 422 Delete Backup V1 Backups  Id  Delete
-            x-viveiro: true
-            x-mgc-hidden: true
-            security:
-            -   OAuth2:
-                - block-storage.write
-    /v1/backups/{id}/rename:
-        patch:
-            tags:
-            - backups
-            summary: Rename a backup.
-            description: "Patches a Backup for the currently authenticated tenant.\n\
-                \n#### Rules\n- The Backup name must be unique; otherwise, renaming\
-                \ will not be allowed.\n- The Backup's state must be available.\n\n\
-                #### Notes\n- Utilize the **block-storage backups list** command to\
-                \ retrieve a list of\n all Backups and obtain the ID of the Backup\
-                \ you wish to rename."
-            operationId: patch_backup_v1_backups__id__rename_patch
-            parameters:
-            -   name: id
-                in: path
-                required: true
-                schema:
-                    type: string
-                    title: Id
-                    format: uuid
-            requestBody:
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/PatchResourceRequest'
-                required: true
-            responses:
-                '204':
-                    description: Successful Response
-                '404':
-                    description: Not Found
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 404 Patch Backup V1 Backups  Id  Rename
-                                    Patch
-                '409':
-                    description: Conflict
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 409 Patch Backup V1 Backups  Id  Rename
-                                    Patch
-                '422':
-                    description: Unprocessable Entity
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/ErrorResponse'
-                                title: Response 422 Patch Backup V1 Backups  Id  Rename
-                                    Patch
-            x-viveiro: true
-            x-mgc-hidden: true
-            security:
-            -   OAuth2:
-                - block-storage.write
     /v1/snapshots:
         get:
             tags:
@@ -1997,358 +1601,16 @@ components:
                     state: running
                     status: completed
                     updated_at: '2022-01-01T00:00:10Z'
-        BackupIdRequest:
-            type: object
-            properties:
-                id:
-                    anyOf:
-                    -   type: string
-                        maxLength: 255
-                        minLength: 1
-                    title: Id
-                    nullable: true
-                name:
-                    anyOf:
-                    -   type: string
-                        maxLength: 255
-                        minLength: 1
-                    title: Name
-                    nullable: true
-            title: BackupIdRequest
-        BackupListResponse:
-            type: object
-            properties:
-                backups:
-                    type: array
-                    items:
-                        type: object
-                        properties:
-                            id:
-                                type: string
-                                title: Id
-                            name:
-                                type: string
-                                title: Name
-                            size:
-                                type: integer
-                                title: Size
-                            description:
-                                anyOf:
-                                -   type: string
-                                title: Description
-                                nullable: true
-                            state:
-                                type: string
-                                title: BackupState
-                                enum:
-                                - new
-                                - available
-                                - deleted
-                            status:
-                                type: string
-                                title: BackupStatus
-                                enum:
-                                - completed
-                                - creating
-                                - creating_error
-                                - creating_error_quota
-                                - uploading
-                                - uploading_error_quota
-                                - uploading_error
-                                - deleting_pending
-                                - deleting_error
-                                - deleting
-                                - restoring_pending
-                                - restoring
-                                - restoring_error
-                                - provisioning
-                                - copying
-                                - copying_error_quota
-                            created_at:
-                                anyOf:
-                                -   type: string
-                                -   type: string
-                                    format: date-time
-                                title: Created At
-                                example: '2022-01-01T00:00:10Z'
-                            updated_at:
-                                anyOf:
-                                -   type: string
-                                -   type: string
-                                    format: date-time
-                                title: Updated At
-                                example: '2022-01-01T00:00:10Z'
-                            volume:
-                                anyOf:
-                                -   $ref: '#/components/schemas/ExpandedVolume'
-                                -   $ref: '#/components/schemas/IdResponse'
-                                title: Volume
-                                nullable: true
-                            type:
-                                type: string
-                                title: BackupType
-                                enum:
-                                - full
-                                - incremental
-                            source_backup:
-                                anyOf:
-                                -   $ref: '#/components/schemas/IdResponse'
-                                nullable: true
-                            error:
-                                anyOf:
-                                -   $ref: '#/components/schemas/BackupResponseError'
-                                nullable: true
-                        title: BackupResponse
-                        required:
-                        - id
-                        - name
-                        - size
-                        - state
-                        - status
-                        - created_at
-                        - updated_at
-                        - volume
-                        - type
-                        example:
-                            created_at: '2022-01-01T00:00:10Z'
-                            description: my backup for testing
-                            error:
-                                message: You have reached the limit of allowed backups.
-                                    Please, remove unused backups or contact support
-                                    to increase your quota.
-                                slug: creating_error_quota
-                            id: a7ce0545-7a0e-4192-97e7-659aaa66b5c4
-                            name: My backup
-                            size: 10
-                            source_backup:
-                                id: cf495c8d-5b1c-4e3e-b991-f6642944d7a7
-                            state: available
-                            status: completed
-                            type: incremental
-                            updated_at: '2022-01-01T00:00:10Z'
-                            volume:
-                                id: 3961ab7f-4939-4ea0-8f7e-25a2e30731b7
-                    title: Backups
-            title: BackupListResponse
-            required:
-            - backups
-            example:
-                backups:
-                -   created_at: '2022-01-01T00:00:10Z'
-                    description: my backup for testing
-                    error:
-                        message: You have reached the limit of allowed backups. Please,
-                            remove unused backups or contact support to increase your
-                            quota.
-                        slug: creating_error_quota
-                    id: a7ce0545-7a0e-4192-97e7-659aaa66b5c4
-                    name: My backup
-                    size: 10
-                    source_backup:
-                        id: cf495c8d-5b1c-4e3e-b991-f6642944d7a7
-                    state: available
-                    status: completed
-                    type: incremental
-                    updated_at: '2022-01-01T00:00:10Z'
-                    volume:
-                        id: 3961ab7f-4939-4ea0-8f7e-25a2e30731b7
-        BackupResponse:
-            type: object
-            properties:
-                id:
-                    type: string
-                    title: Id
-                name:
-                    type: string
-                    title: Name
-                size:
-                    type: integer
-                    title: Size
-                description:
-                    anyOf:
-                    -   type: string
-                    title: Description
-                    nullable: true
-                state:
-                    type: string
-                    title: BackupState
-                    enum:
-                    - new
-                    - available
-                    - deleted
-                status:
-                    type: string
-                    title: BackupStatus
-                    enum:
-                    - completed
-                    - creating
-                    - creating_error
-                    - creating_error_quota
-                    - uploading
-                    - uploading_error_quota
-                    - uploading_error
-                    - deleting_pending
-                    - deleting_error
-                    - deleting
-                    - restoring_pending
-                    - restoring
-                    - restoring_error
-                    - provisioning
-                    - copying
-                    - copying_error_quota
-                created_at:
-                    anyOf:
-                    -   type: string
-                    -   type: string
-                        format: date-time
-                    title: Created At
-                    example: '2022-01-01T00:00:10Z'
-                updated_at:
-                    anyOf:
-                    -   type: string
-                    -   type: string
-                        format: date-time
-                    title: Updated At
-                    example: '2022-01-01T00:00:10Z'
-                volume:
-                    anyOf:
-                    -   $ref: '#/components/schemas/ExpandedVolume'
-                    -   $ref: '#/components/schemas/IdResponse'
-                    title: Volume
-                    nullable: true
-                type:
-                    type: string
-                    title: BackupType
-                    enum:
-                    - full
-                    - incremental
-                source_backup:
-                    anyOf:
-                    -   $ref: '#/components/schemas/IdResponse'
-                    nullable: true
-                error:
-                    anyOf:
-                    -   $ref: '#/components/schemas/BackupResponseError'
-                    nullable: true
-            title: BackupResponse
-            required:
-            - id
-            - name
-            - size
-            - state
-            - status
-            - created_at
-            - updated_at
-            - volume
-            - type
-            example:
-                created_at: '2022-01-01T00:00:10Z'
-                description: my backup for testing
-                error:
-                    message: You have reached the limit of allowed backups. Please,
-                        remove unused backups or contact support to increase your
-                        quota.
-                    slug: creating_error_quota
-                id: a7ce0545-7a0e-4192-97e7-659aaa66b5c4
-                name: My backup
-                size: 10
-                source_backup:
-                    id: cf495c8d-5b1c-4e3e-b991-f6642944d7a7
-                state: available
-                status: completed
-                type: incremental
-                updated_at: '2022-01-01T00:00:10Z'
-                volume:
-                    id: 3961ab7f-4939-4ea0-8f7e-25a2e30731b7
-        BackupResponseError:
-            type: object
-            properties:
-                message:
-                    title: Message
-                    type: string
-                slug:
-                    title: Slug
-                    type: string
-            title: BackupResponseError
-            required:
-            - slug
-            - message
-            example:
-                message: Unauthorized
-                slug: Unauthorized
-        BackupState:
-            type: string
-            title: BackupState
-            enum:
-            - new
-            - available
-            - deleted
-        BackupStatus:
-            type: string
-            title: BackupStatus
-            enum:
-            - completed
-            - creating
-            - creating_error
-            - creating_error_quota
-            - uploading
-            - uploading_error_quota
-            - uploading_error
-            - deleting_pending
-            - deleting_error
-            - deleting
-            - restoring_pending
-            - restoring
-            - restoring_error
-            - provisioning
-            - copying
-            - copying_error_quota
-        BackupType:
-            type: string
-            title: BackupType
-            enum:
-            - full
-            - incremental
-        CopyBackupCrossRegionRequest:
-            type: object
-            properties:
-                destiny_region:
-                    type: string
-                    title: Destiny Region
-                    maxLength: 255
-                    minLength: 1
-                backup:
-                    type: object
-                    properties:
-                        id:
-                            anyOf:
-                            -   type: string
-                                maxLength: 255
-                                minLength: 1
-                            title: Id
-                            nullable: true
-                        name:
-                            anyOf:
-                            -   type: string
-                                maxLength: 255
-                                minLength: 1
-                            title: Name
-                            nullable: true
-                    title: BackupIdRequest
-            title: CopyBackupCrossRegionRequest
-            required:
-            - destiny_region
-            - backup
-            example:
-                backup:
-                    name: backup-tomato
-                destiny_region: br-ne1
         CopyCrossRegionRequest:
             type: object
             properties:
                 destination_region:
                     type: string
-                    title: Destination Region
+                    title: Regions
+                    enum:
+                    - br-se1
+                    - br-mgl1
+                    - br-ne1
             title: CopyCrossRegionRequest
             required:
             - destination_region
@@ -2396,38 +1658,6 @@ components:
                     id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
                 volume:
                     id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-        CreateBackup:
-            type: object
-            properties:
-                description:
-                    anyOf:
-                    -   type: string
-                    title: Description
-                    nullable: true
-                volume:
-                    anyOf:
-                    -   $ref: '#/components/schemas/IdRequest'
-                    -   $ref: '#/components/schemas/Name'
-                    title: Volume
-                name:
-                    type: string
-                    title: Name
-                type:
-                    type: string
-                    title: BackupType
-                    enum:
-                    - full
-                    - incremental
-            title: CreateBackup
-            required:
-            - volume
-            - name
-            example:
-                description: my-backup
-                name: backup name
-                type: full
-                volume:
-                    id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
         DiskType:
             type: string
             title: DiskType
@@ -2451,100 +1681,11 @@ components:
             example:
                 message: Unauthorized
                 slug: Unauthorized
-        ExpandBackup:
-            type: string
-            title: ExpandBackup
-            enum:
-            - volume
         ExpandSnapshots:
             type: string
             title: ExpandSnapshots
             enum:
             - volume
-        ExpandedVolume:
-            type: object
-            properties:
-                id:
-                    type: string
-                    title: Id
-                name:
-                    type: string
-                    title: Name
-                state:
-                    type: string
-                    title: VolumeStateV1
-                    enum:
-                    - new
-                    - available
-                    - in-use
-                    - deleted
-                    - legacy
-                status:
-                    type: string
-                    title: VolumeStatusV1
-                    enum:
-                    - provisioning
-                    - creating
-                    - creating_error
-                    - creating_error_quota
-                    - completed
-                    - extend_pending
-                    - extending
-                    - extend_error
-                    - extend_error_quota
-                    - attaching_pending
-                    - attaching_error
-                    - attaching
-                    - detaching_pending
-                    - detaching_error
-                    - detaching
-                    - retype_pending
-                    - retyping
-                    - retype_error
-                    - retype_error_quota
-                    - deleting_pending
-                    - deleting
-                    - deleted
-                    - deleted_error
-                size:
-                    type: integer
-                    title: Size
-                created_at:
-                    anyOf:
-                    -   type: string
-                    -   type: string
-                        format: date-time
-                    title: Created At
-                    example: '2022-01-01T00:00:10Z'
-                updated_at:
-                    anyOf:
-                    -   type: string
-                    -   type: string
-                        format: date-time
-                    title: Updated At
-                    example: '2022-01-01T00:00:10Z'
-                volume_type:
-                    type: object
-                    properties:
-                        id:
-                            type: string
-                            title: Id
-                            minLength: 1
-                    title: IdResponse
-                    required:
-                    - id
-                    example:
-                        id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-            title: ExpandedVolume
-            required:
-            - id
-            - name
-            - state
-            - status
-            - size
-            - created_at
-            - updated_at
-            - volume_type
         GenericVolumeTypeList_VolumeTypeResponseWithAzs_:
             type: object
             properties:
@@ -2598,6 +1739,10 @@ components:
                                 items:
                                     type: string
                                 title: Availability Zones
+                            allows_encryption:
+                                type: boolean
+                                title: Allows Encryption
+                                default: false
                         title: VolumeTypeResponseWithAzs
                         required:
                         - iops
@@ -2607,6 +1752,7 @@ components:
                         - status
                         - availability_zones
                         example:
+                            allows_encryption: true
                             availability_zones:
                             - a
                             disk_type: nvme
@@ -2623,7 +1769,8 @@ components:
             - types
             example:
                 types:
-                -   availability_zones:
+                -   allows_encryption: true
+                    availability_zones:
                     - a
                     disk_type: nvme
                     id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -2718,27 +1865,13 @@ components:
             - name
             example:
                 name: some_resource_name
-        PatchResourceRequest:
-            type: object
-            properties:
-                name:
-                    anyOf:
-                    -   type: string
-                        maxLength: 255
-                        minLength: 1
-                    title: Name
-                    nullable: true
-                description:
-                    anyOf:
-                    -   type: string
-                        maxLength: 255
-                        minLength: 1
-                    title: Description
-                    nullable: true
-            title: PatchResourceRequest
-            example:
-                description: new description to my resource
-                name: new name to my resource
+        Regions:
+            type: string
+            title: Regions
+            enum:
+            - br-se1
+            - br-mgl1
+            - br-ne1
         RenameVolumeRequest:
             type: object
             properties:
@@ -3197,6 +2330,12 @@ components:
                     -   $ref: '#/components/schemas/Name'
                     title: Snapshot
                     nullable: true
+                encrypted:
+                    type: boolean
+                    title: Encrypted
+                    description: Indicates if the volume is encrypted. Default is
+                        False.
+                    default: false
             title: VolumeCreateRequestV1
             required:
             - name
@@ -3204,6 +2343,7 @@ components:
             - type
             example:
                 availability_zone: br-se1-a
+                encrypted: false
                 name: volume-name
                 size: 10
                 snapshot:
@@ -3322,6 +2462,10 @@ components:
                     items:
                         type: string
                     title: Availability Zones
+                encrypted:
+                    type: boolean
+                    title: Encrypted
+                    default: false
             title: VolumeResponseV1
             required:
             - id
@@ -3349,6 +2493,7 @@ components:
                 availability_zones:
                 - br-ne1-a
                 created_at: '2022-01-01T00:00:10Z'
+                encrypted: false
                 error:
                     message: You have reached the limit of allowed disks. Please,
                         remove unused disks or contact support to increase your quota.
@@ -3518,6 +2663,10 @@ components:
                     items:
                         type: string
                     title: Availability Zones
+                allows_encryption:
+                    type: boolean
+                    title: Allows Encryption
+                    default: false
             title: VolumeTypeResponseWithAzs
             required:
             - iops
@@ -3527,6 +2676,7 @@ components:
             - status
             - availability_zones
             example:
+                allows_encryption: true
                 availability_zones:
                 - a
                 disk_type: nvme
@@ -3653,6 +2803,10 @@ components:
                                 items:
                                     type: string
                                 title: Availability Zones
+                            encrypted:
+                                type: boolean
+                                title: Encrypted
+                                default: false
                         title: VolumeResponseV1
                         required:
                         - id
@@ -3680,6 +2834,7 @@ components:
                             availability_zones:
                             - br-ne1-a
                             created_at: '2022-01-01T00:00:10Z'
+                            encrypted: false
                             error:
                                 message: You have reached the limit of allowed disks.
                                     Please, remove unused disks or contact support
@@ -3713,6 +2868,7 @@ components:
                     availability_zones:
                     - br-ne1-a
                     created_at: '2022-01-01T00:00:10Z'
+                    encrypted: false
                     error:
                         message: You have reached the limit of allowed disks. Please,
                             remove unused disks or contact support to increase your

--- a/mgc/spec_manipulator/cli_specs/block-storage.jaxyendy.openapi.json
+++ b/mgc/spec_manipulator/cli_specs/block-storage.jaxyendy.openapi.json
@@ -169,578 +169,6 @@
         "x-viveiro": true
       }
     },
-    "/v1/backups": {
-      "get": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "List all backups.",
-        "description": "Retrieve a list of Backups for the currently authenticated tenant.\n\n#### Notes\n- Use the **expand** argument to obtain additional details about the\n Volume used to create each Backup.",
-        "operationId": "list_backups_v1_backups_get",
-        "parameters": [
-          {
-            "name": "expand",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExpandBackup"
-              },
-              "title": "Expand",
-              "default": []
-            }
-          },
-          {
-            "name": "_limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "exclusiveMinimum": 0,
-              "type": "integer",
-              "title": " Limit",
-              "default": 50
-            }
-          },
-          {
-            "name": "_offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "title": " Offset",
-              "minimum": 0,
-              "default": 0
-            }
-          },
-          {
-            "name": "_sort",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": " Sort",
-              "pattern": "^(^[\\w-]+:(asc|desc)(,[\\w-]+:(asc|desc))*)?$",
-              "default": "created_at:asc"
-            }
-          },
-          {
-            "name": "name",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Name"
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BackupListResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 List Backups V1 Backups Get"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 List Backups V1 Backups Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 List Backups V1 Backups Get"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      },
-      "post": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Create a backup.",
-        "description": "Create a backup for the currently authenticated tenant.\n\nThe Backup can be used when it reaches the \"available\" state and the\n \"completed\" status.\n\n#### Rules\n- The Backup name must be unique; otherwise, the creation will be disallowed.\n- The Volume can be either in in-use or available states.\n- The Volume must not have an operation in execution.\n\n#### Notes\n- Use the **block-storage volume list** command to retrieve a list of all\n Volumes and obtain the ID of the Volume that will be used to create the\n Backup.",
-        "operationId": "create_backup_v1_backups_post",
-        "parameters": [
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateBackup"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IdResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Create Backup V1 Backups Post"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Create Backup V1 Backups Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Create Backup V1 Backups Post"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
-    "/v1/backups/copy": {
-      "post": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Copy backup cross region.",
-        "description": "Copy a backup cross region for the currently authenticated tenant.\n\n#### Rules\n- The copy only be accepted when the destiny region is different from origin region.\n- The copy only be accepted if the backup's name in destiny region is different from input name.\n- The copy only be accepted if the user has access to destiny region.\n\n#### Notes\n- Utilize the **block-storage backups list** command to retrieve a list of\n all Backups and obtain the ID of the Backup you wish to copy across different region.",
-        "operationId": "copy_backup_cross_region_v1_backups_copy_post",
-        "parameters": [
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CopyBackupCrossRegionRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Copy Backup Cross Region V1 Backups Copy Post"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Copy Backup Cross Region V1 Backups Copy Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Copy Backup Cross Region V1 Backups Copy Post"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
-    "/v1/backups/{id}": {
-      "get": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Retrieve the details of a specific backup.",
-        "description": "Retrieve details of a Backup for the currently authenticated tenant.\n\n#### Notes\n- Use the **expand** argument to obtain additional details about the Volume\n used to create the Backup.\n- Utilize the **block-storage backups list** command to retrieve a list of\n all Backups and obtain the ID of the Backup for which you want to retrieve\n details.",
-        "operationId": "get_backup_v1_backups__id__get",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Id",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "expand",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/ExpandBackup"
-              },
-              "title": "Expand",
-              "default": []
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BackupResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Get Backup V1 Backups  Id  Get"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Get Backup V1 Backups  Id  Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Get Backup V1 Backups  Id  Get"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      },
-      "delete": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Delete a backup.",
-        "description": "Delete a Backup for the currently authenticated tenant.\n\n#### Rules\n- The Backup's status must be \"completed\".\n- The Backup's state must be \"available\".\n\n\n#### Notes\n- Utilize the **block-storage backups** list command to retrieve a list of\n all Backups and obtain the ID of the Backup you wish to delete.",
-        "operationId": "delete_backup_v1_backups__id__delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Id",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Delete Backup V1 Backups  Id  Delete"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Delete Backup V1 Backups  Id  Delete"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Delete Backup V1 Backups  Id  Delete"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
-    "/v1/backups/{id}/rename": {
-      "patch": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Rename a backup.",
-        "description": "Patches a Backup for the currently authenticated tenant.\n\n#### Rules\n- The Backup name must be unique; otherwise, renaming will not be allowed.\n- The Backup's state must be available.\n\n#### Notes\n- Utilize the **block-storage backups list** command to retrieve a list of\n all Backups and obtain the ID of the Backup you wish to rename.",
-        "operationId": "patch_backup_v1_backups__id__rename_patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Id",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PatchResourceRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Patch Backup V1 Backups  Id  Rename Patch"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Patch Backup V1 Backups  Id  Rename Patch"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Patch Backup V1 Backups  Id  Rename Patch"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
     "/v1/snapshots": {
       "get": {
         "tags": [
@@ -2371,305 +1799,11 @@
           }
         }
       },
-      "BackupIdRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Id"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          }
-        },
-        "title": "BackupIdRequest"
-      },
-      "BackupListResponse": {
-        "type": "object",
-        "properties": {
-          "backups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/BackupResponse"
-            },
-            "title": "Backups"
-          }
-        },
-        "title": "BackupListResponse",
-        "required": [
-          "backups"
-        ],
-        "example": {
-          "backups": [
-            {
-              "created_at": "2022-01-01T00:00:10Z",
-              "description": "my backup for testing",
-              "error": {
-                "message": "You have reached the limit of allowed backups. Please, remove unused backups or contact support to increase your quota.",
-                "slug": "creating_error_quota"
-              },
-              "id": "a7ce0545-7a0e-4192-97e7-659aaa66b5c4",
-              "name": "My backup",
-              "size": 10,
-              "source_backup": {
-                "id": "cf495c8d-5b1c-4e3e-b991-f6642944d7a7"
-              },
-              "state": "available",
-              "status": "completed",
-              "type": "incremental",
-              "updated_at": "2022-01-01T00:00:10Z",
-              "volume": {
-                "id": "3961ab7f-4939-4ea0-8f7e-25a2e30731b7"
-              }
-            }
-          ]
-        }
-      },
-      "BackupResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "state": {
-            "$ref": "#/components/schemas/BackupState"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BackupStatus"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "examples": [
-              "2022-01-01T00:00:10Z"
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "examples": [
-              "2022-01-01T00:00:10Z"
-            ],
-            "title": "Updated At"
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ExpandedVolume"
-              },
-              {
-                "$ref": "#/components/schemas/IdResponse"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Volume"
-          },
-          "type": {
-            "$ref": "#/components/schemas/BackupType"
-          },
-          "source_backup": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/IdResponse"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "error": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BackupResponseError"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "title": "BackupResponse",
-        "required": [
-          "id",
-          "name",
-          "size",
-          "state",
-          "status",
-          "created_at",
-          "updated_at",
-          "volume",
-          "type"
-        ],
-        "example": {
-          "created_at": "2022-01-01T00:00:10Z",
-          "description": "my backup for testing",
-          "error": {
-            "message": "You have reached the limit of allowed backups. Please, remove unused backups or contact support to increase your quota.",
-            "slug": "creating_error_quota"
-          },
-          "id": "a7ce0545-7a0e-4192-97e7-659aaa66b5c4",
-          "name": "My backup",
-          "size": 10,
-          "source_backup": {
-            "id": "cf495c8d-5b1c-4e3e-b991-f6642944d7a7"
-          },
-          "state": "available",
-          "status": "completed",
-          "type": "incremental",
-          "updated_at": "2022-01-01T00:00:10Z",
-          "volume": {
-            "id": "3961ab7f-4939-4ea0-8f7e-25a2e30731b7"
-          }
-        }
-      },
-      "BackupResponseError": {
-        "type": "object",
-        "properties": {
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
-        },
-        "title": "BackupResponseError",
-        "required": [
-          "slug",
-          "message"
-        ],
-        "example": {
-          "message": "You have reached the limit of allowed backups. Please, remove unused backups or contact support to increase your quota.",
-          "slug": "creating_error_quota"
-        }
-      },
-      "BackupState": {
-        "type": "string",
-        "title": "BackupState",
-        "enum": [
-          "new",
-          "available",
-          "deleted"
-        ]
-      },
-      "BackupStatus": {
-        "type": "string",
-        "title": "BackupStatus",
-        "enum": [
-          "completed",
-          "creating",
-          "creating_error",
-          "creating_error_quota",
-          "uploading",
-          "uploading_error_quota",
-          "uploading_error",
-          "deleting_pending",
-          "deleting_error",
-          "deleting",
-          "restoring_pending",
-          "restoring",
-          "restoring_error",
-          "provisioning",
-          "copying",
-          "copying_error_quota"
-        ]
-      },
-      "BackupType": {
-        "type": "string",
-        "title": "BackupType",
-        "enum": [
-          "full",
-          "incremental"
-        ]
-      },
-      "CopyBackupCrossRegionRequest": {
-        "type": "object",
-        "properties": {
-          "destiny_region": {
-            "type": "string",
-            "title": "Destiny Region",
-            "maxLength": 255,
-            "minLength": 1
-          },
-          "backup": {
-            "$ref": "#/components/schemas/BackupIdRequest"
-          }
-        },
-        "title": "CopyBackupCrossRegionRequest",
-        "required": [
-          "destiny_region",
-          "backup"
-        ],
-        "example": {
-          "backup": {
-            "name": "backup-tomato"
-          },
-          "destiny_region": "br-ne1"
-        }
-      },
       "CopyCrossRegionRequest": {
         "type": "object",
         "properties": {
           "destination_region": {
-            "type": "string",
-            "title": "Destination Region"
+            "$ref": "#/components/schemas/Regions"
           }
         },
         "title": "CopyCrossRegionRequest",
@@ -2716,54 +1850,6 @@
           }
         }
       },
-      "CreateBackup": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/IdRequest"
-              },
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ],
-            "title": "Volume"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "type": {
-            "$ref": "#/components/schemas/BackupType",
-            "default": "full"
-          }
-        },
-        "title": "CreateBackup",
-        "required": [
-          "volume",
-          "name"
-        ],
-        "example": {
-          "description": "my-backup",
-          "name": "backup name",
-          "type": "full",
-          "volume": {
-            "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-          }
-        }
-      },
       "DiskType": {
         "type": "string",
         "title": "DiskType",
@@ -2800,85 +1886,11 @@
           "slug": "generic"
         }
       },
-      "ExpandBackup": {
-        "type": "string",
-        "title": "ExpandBackup",
-        "enum": [
-          "volume"
-        ]
-      },
       "ExpandSnapshots": {
         "type": "string",
         "title": "ExpandSnapshots",
         "enum": [
           "volume"
-        ]
-      },
-      "ExpandedVolume": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "state": {
-            "$ref": "#/components/schemas/VolumeStateV1"
-          },
-          "status": {
-            "$ref": "#/components/schemas/VolumeStatusV1"
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "examples": [
-              "2022-01-01T00:00:10Z"
-            ],
-            "title": "Created At"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "examples": [
-              "2022-01-01T00:00:10Z"
-            ],
-            "title": "Updated At"
-          },
-          "volume_type": {
-            "$ref": "#/components/schemas/IdResponse"
-          }
-        },
-        "title": "ExpandedVolume",
-        "required": [
-          "id",
-          "name",
-          "state",
-          "status",
-          "size",
-          "created_at",
-          "updated_at",
-          "volume_type"
         ]
       },
       "GenericVolumeTypeList_VolumeTypeResponseWithAzs_": {
@@ -2899,6 +1911,7 @@
         "example": {
           "types": [
             {
+              "allows_encryption": true,
               "availability_zones": [
                 "a"
               ],
@@ -3019,41 +2032,14 @@
           "name": "some_resource_name"
         }
       },
-      "PatchResourceRequest": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          }
-        },
-        "title": "PatchResourceRequest",
-        "example": {
-          "description": "new description to my resource",
-          "name": "new name to my resource"
-        }
+      "Regions": {
+        "type": "string",
+        "title": "Regions",
+        "enum": [
+          "br-se1",
+          "br-mgl1",
+          "br-ne1"
+        ]
       },
       "RenameVolumeRequest": {
         "type": "object",
@@ -3536,6 +2522,12 @@
               }
             ],
             "title": "Snapshot"
+          },
+          "encrypted": {
+            "type": "boolean",
+            "title": "Encrypted",
+            "description": "Indicates if the volume is encrypted. Default is False.",
+            "default": false
           }
         },
         "title": "VolumeCreateRequestV1",
@@ -3546,6 +2538,7 @@
         ],
         "example": {
           "availability_zone": "br-se1-a",
+          "encrypted": false,
           "name": "volume-name",
           "size": 10,
           "snapshot": {
@@ -3688,6 +2681,11 @@
               "type": "string"
             },
             "title": "Availability Zones"
+          },
+          "encrypted": {
+            "type": "boolean",
+            "title": "Encrypted",
+            "default": false
           }
         },
         "title": "VolumeResponseV1",
@@ -3721,6 +2719,7 @@
             "br-ne1-a"
           ],
           "created_at": "2022-01-01T00:00:10Z",
+          "encrypted": false,
           "error": {
             "message": "You have reached the limit of allowed disks. Please, remove unused disks or contact support to increase your quota.",
             "slug": "creating_error_quota"
@@ -3868,6 +2867,11 @@
               "type": "string"
             },
             "title": "Availability Zones"
+          },
+          "allows_encryption": {
+            "type": "boolean",
+            "title": "Allows Encryption",
+            "default": false
           }
         },
         "title": "VolumeTypeResponseWithAzs",
@@ -3880,6 +2884,7 @@
           "availability_zones"
         ],
         "example": {
+          "allows_encryption": true,
           "availability_zones": [
             "a"
           ],
@@ -3966,6 +2971,7 @@
                 "br-ne1-a"
               ],
               "created_at": "2022-01-01T00:00:10Z",
+              "encrypted": false,
               "error": {
                 "message": "You have reached the limit of allowed disks. Please, remove unused disks or contact support to increase your quota.",
                 "slug": "creating_error_quota"

--- a/mgc/spec_manipulator/cli_specs/conv.block-storage.jaxyendy.openapi.json
+++ b/mgc/spec_manipulator/cli_specs/conv.block-storage.jaxyendy.openapi.json
@@ -169,583 +169,6 @@
         "x-viveiro": true
       }
     },
-    "/v1/backups": {
-      "get": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "List all backups.",
-        "description": "Retrieve a list of Backups for the currently authenticated tenant.\n\n#### Notes\n- Use the **expand** argument to obtain additional details about the\n Volume used to create each Backup.",
-        "operationId": "list_backups_v1_backups_get",
-        "parameters": [
-          {
-            "name": "expand",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "title": "ExpandBackup",
-                "enum": [
-                  "volume"
-                ]
-              },
-              "title": "Expand",
-              "default": []
-            }
-          },
-          {
-            "name": "_limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "exclusiveMinimum": false,
-              "type": "integer",
-              "title": " Limit",
-              "default": 50
-            }
-          },
-          {
-            "name": "_offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "title": " Offset",
-              "default": 0
-            }
-          },
-          {
-            "name": "_sort",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "title": " Sort",
-              "pattern": "^(^[\\w-]+:(asc|desc)(,[\\w-]+:(asc|desc))*)?$",
-              "default": "created_at:asc"
-            }
-          },
-          {
-            "name": "name",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                }
-              ],
-              "title": "Name",
-              "nullable": true
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BackupListResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 List Backups V1 Backups Get"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 List Backups V1 Backups Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 List Backups V1 Backups Get"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      },
-      "post": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Create a backup.",
-        "description": "Create a backup for the currently authenticated tenant.\n\nThe Backup can be used when it reaches the \"available\" state and the\n \"completed\" status.\n\n#### Rules\n- The Backup name must be unique; otherwise, the creation will be disallowed.\n- The Volume can be either in in-use or available states.\n- The Volume must not have an operation in execution.\n\n#### Notes\n- Use the **block-storage volume list** command to retrieve a list of all\n Volumes and obtain the ID of the Volume that will be used to create the\n Backup.",
-        "operationId": "create_backup_v1_backups_post",
-        "parameters": [
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateBackup"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "202": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IdResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Create Backup V1 Backups Post"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Create Backup V1 Backups Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Create Backup V1 Backups Post"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
-    "/v1/backups/copy": {
-      "post": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Copy backup cross region.",
-        "description": "Copy a backup cross region for the currently authenticated tenant.\n\n#### Rules\n- The copy only be accepted when the destiny region is different from origin region.\n- The copy only be accepted if the backup's name in destiny region is different from input name.\n- The copy only be accepted if the user has access to destiny region.\n\n#### Notes\n- Utilize the **block-storage backups list** command to retrieve a list of\n all Backups and obtain the ID of the Backup you wish to copy across different region.",
-        "operationId": "copy_backup_cross_region_v1_backups_copy_post",
-        "parameters": [
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CopyBackupCrossRegionRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Copy Backup Cross Region V1 Backups Copy Post"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Copy Backup Cross Region V1 Backups Copy Post"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Copy Backup Cross Region V1 Backups Copy Post"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
-    "/v1/backups/{id}": {
-      "get": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Retrieve the details of a specific backup.",
-        "description": "Retrieve details of a Backup for the currently authenticated tenant.\n\n#### Notes\n- Use the **expand** argument to obtain additional details about the Volume\n used to create the Backup.\n- Utilize the **block-storage backups list** command to retrieve a list of\n all Backups and obtain the ID of the Backup for which you want to retrieve\n details.",
-        "operationId": "get_backup_v1_backups__id__get",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Id",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "expand",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "title": "ExpandBackup",
-                "enum": [
-                  "volume"
-                ]
-              },
-              "title": "Expand",
-              "default": []
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BackupResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Get Backup V1 Backups  Id  Get"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Get Backup V1 Backups  Id  Get"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Get Backup V1 Backups  Id  Get"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      },
-      "delete": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Delete a backup.",
-        "description": "Delete a Backup for the currently authenticated tenant.\n\n#### Rules\n- The Backup's status must be \"completed\".\n- The Backup's state must be \"available\".\n\n\n#### Notes\n- Utilize the **block-storage backups** list command to retrieve a list of\n all Backups and obtain the ID of the Backup you wish to delete.",
-        "operationId": "delete_backup_v1_backups__id__delete",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Id",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Delete Backup V1 Backups  Id  Delete"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Delete Backup V1 Backups  Id  Delete"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Delete Backup V1 Backups  Id  Delete"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
-    "/v1/backups/{id}/rename": {
-      "patch": {
-        "tags": [
-          "backups"
-        ],
-        "summary": "Rename a backup.",
-        "description": "Patches a Backup for the currently authenticated tenant.\n\n#### Rules\n- The Backup name must be unique; otherwise, renaming will not be allowed.\n- The Backup's state must be available.\n\n#### Notes\n- Utilize the **block-storage backups list** command to retrieve a list of\n all Backups and obtain the ID of the Backup you wish to rename.",
-        "operationId": "patch_backup_v1_backups__id__rename_patch",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "Id",
-              "format": "uuid"
-            }
-          },
-          {
-            "name": "x-tenant-id",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "title": "X-Tenant-Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PatchResourceRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 404 Patch Backup V1 Backups  Id  Rename Patch"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 409 Patch Backup V1 Backups  Id  Rename Patch"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ErrorResponse"
-                  },
-                  "title": "Response 422 Patch Backup V1 Backups  Id  Rename Patch"
-                }
-              }
-            }
-          }
-        },
-        "x-viveiro": true,
-        "x-mgc-hidden": true
-      }
-    },
     "/v1/snapshots": {
       "get": {
         "tags": [
@@ -2356,493 +1779,17 @@
           }
         }
       },
-      "BackupIdRequest": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              }
-            ],
-            "title": "Id",
-            "nullable": true
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              }
-            ],
-            "title": "Name",
-            "nullable": true
-          }
-        },
-        "title": "BackupIdRequest"
-      },
-      "BackupListResponse": {
-        "type": "object",
-        "properties": {
-          "backups": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "title": "Id"
-                },
-                "name": {
-                  "type": "string",
-                  "title": "Name"
-                },
-                "size": {
-                  "type": "integer",
-                  "title": "Size"
-                },
-                "description": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    }
-                  ],
-                  "title": "Description",
-                  "nullable": true
-                },
-                "state": {
-                  "type": "string",
-                  "title": "BackupState",
-                  "enum": [
-                    "new",
-                    "available",
-                    "deleted"
-                  ]
-                },
-                "status": {
-                  "type": "string",
-                  "title": "BackupStatus",
-                  "enum": [
-                    "completed",
-                    "creating",
-                    "creating_error",
-                    "creating_error_quota",
-                    "uploading",
-                    "uploading_error_quota",
-                    "uploading_error",
-                    "deleting_pending",
-                    "deleting_error",
-                    "deleting",
-                    "restoring_pending",
-                    "restoring",
-                    "restoring_error",
-                    "provisioning",
-                    "copying",
-                    "copying_error_quota"
-                  ]
-                },
-                "created_at": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  ],
-                  "title": "Created At",
-                  "example": "2022-01-01T00:00:10Z"
-                },
-                "updated_at": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  ],
-                  "title": "Updated At",
-                  "example": "2022-01-01T00:00:10Z"
-                },
-                "volume": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/ExpandedVolume"
-                    },
-                    {
-                      "$ref": "#/components/schemas/IdResponse"
-                    }
-                  ],
-                  "title": "Volume",
-                  "nullable": true
-                },
-                "type": {
-                  "type": "string",
-                  "title": "BackupType",
-                  "enum": [
-                    "full",
-                    "incremental"
-                  ]
-                },
-                "source_backup": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/IdResponse"
-                    }
-                  ],
-                  "nullable": true
-                },
-                "error": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/BackupResponseError"
-                    }
-                  ],
-                  "nullable": true
-                }
-              },
-              "title": "BackupResponse",
-              "required": [
-                "id",
-                "name",
-                "size",
-                "state",
-                "status",
-                "created_at",
-                "updated_at",
-                "volume",
-                "type"
-              ],
-              "example": {
-                "created_at": "2022-01-01T00:00:10Z",
-                "description": "my backup for testing",
-                "error": {
-                  "message": "You have reached the limit of allowed backups. Please, remove unused backups or contact support to increase your quota.",
-                  "slug": "creating_error_quota"
-                },
-                "id": "a7ce0545-7a0e-4192-97e7-659aaa66b5c4",
-                "name": "My backup",
-                "size": 10,
-                "source_backup": {
-                  "id": "cf495c8d-5b1c-4e3e-b991-f6642944d7a7"
-                },
-                "state": "available",
-                "status": "completed",
-                "type": "incremental",
-                "updated_at": "2022-01-01T00:00:10Z",
-                "volume": {
-                  "id": "3961ab7f-4939-4ea0-8f7e-25a2e30731b7"
-                }
-              }
-            },
-            "title": "Backups"
-          }
-        },
-        "title": "BackupListResponse",
-        "required": [
-          "backups"
-        ],
-        "example": {
-          "backups": [
-            {
-              "created_at": "2022-01-01T00:00:10Z",
-              "description": "my backup for testing",
-              "error": {
-                "message": "You have reached the limit of allowed backups. Please, remove unused backups or contact support to increase your quota.",
-                "slug": "creating_error_quota"
-              },
-              "id": "a7ce0545-7a0e-4192-97e7-659aaa66b5c4",
-              "name": "My backup",
-              "size": 10,
-              "source_backup": {
-                "id": "cf495c8d-5b1c-4e3e-b991-f6642944d7a7"
-              },
-              "state": "available",
-              "status": "completed",
-              "type": "incremental",
-              "updated_at": "2022-01-01T00:00:10Z",
-              "volume": {
-                "id": "3961ab7f-4939-4ea0-8f7e-25a2e30731b7"
-              }
-            }
-          ]
-        }
-      },
-      "BackupResponse": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
-            "title": "Description",
-            "nullable": true
-          },
-          "state": {
-            "type": "string",
-            "title": "BackupState",
-            "enum": [
-              "new",
-              "available",
-              "deleted"
-            ]
-          },
-          "status": {
-            "type": "string",
-            "title": "BackupStatus",
-            "enum": [
-              "completed",
-              "creating",
-              "creating_error",
-              "creating_error_quota",
-              "uploading",
-              "uploading_error_quota",
-              "uploading_error",
-              "deleting_pending",
-              "deleting_error",
-              "deleting",
-              "restoring_pending",
-              "restoring",
-              "restoring_error",
-              "provisioning",
-              "copying",
-              "copying_error_quota"
-            ]
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "title": "Created At",
-            "example": "2022-01-01T00:00:10Z"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "title": "Updated At",
-            "example": "2022-01-01T00:00:10Z"
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ExpandedVolume"
-              },
-              {
-                "$ref": "#/components/schemas/IdResponse"
-              }
-            ],
-            "title": "Volume",
-            "nullable": true
-          },
-          "type": {
-            "type": "string",
-            "title": "BackupType",
-            "enum": [
-              "full",
-              "incremental"
-            ]
-          },
-          "source_backup": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/IdResponse"
-              }
-            ],
-            "nullable": true
-          },
-          "error": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/BackupResponseError"
-              }
-            ],
-            "nullable": true
-          }
-        },
-        "title": "BackupResponse",
-        "required": [
-          "id",
-          "name",
-          "size",
-          "state",
-          "status",
-          "created_at",
-          "updated_at",
-          "volume",
-          "type"
-        ],
-        "example": {
-          "created_at": "2022-01-01T00:00:10Z",
-          "description": "my backup for testing",
-          "error": {
-            "message": "You have reached the limit of allowed backups. Please, remove unused backups or contact support to increase your quota.",
-            "slug": "creating_error_quota"
-          },
-          "id": "a7ce0545-7a0e-4192-97e7-659aaa66b5c4",
-          "name": "My backup",
-          "size": 10,
-          "source_backup": {
-            "id": "cf495c8d-5b1c-4e3e-b991-f6642944d7a7"
-          },
-          "state": "available",
-          "status": "completed",
-          "type": "incremental",
-          "updated_at": "2022-01-01T00:00:10Z",
-          "volume": {
-            "id": "3961ab7f-4939-4ea0-8f7e-25a2e30731b7"
-          }
-        }
-      },
-      "BackupResponseError": {
-        "type": "object",
-        "properties": {
-          "slug": {
-            "type": "string",
-            "title": "Slug"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
-        },
-        "title": "BackupResponseError",
-        "required": [
-          "slug",
-          "message"
-        ],
-        "example": {
-          "message": "You have reached the limit of allowed backups. Please, remove unused backups or contact support to increase your quota.",
-          "slug": "creating_error_quota"
-        }
-      },
-      "BackupState": {
-        "type": "string",
-        "title": "BackupState",
-        "enum": [
-          "new",
-          "available",
-          "deleted"
-        ]
-      },
-      "BackupStatus": {
-        "type": "string",
-        "title": "BackupStatus",
-        "enum": [
-          "completed",
-          "creating",
-          "creating_error",
-          "creating_error_quota",
-          "uploading",
-          "uploading_error_quota",
-          "uploading_error",
-          "deleting_pending",
-          "deleting_error",
-          "deleting",
-          "restoring_pending",
-          "restoring",
-          "restoring_error",
-          "provisioning",
-          "copying",
-          "copying_error_quota"
-        ]
-      },
-      "BackupType": {
-        "type": "string",
-        "title": "BackupType",
-        "enum": [
-          "full",
-          "incremental"
-        ]
-      },
-      "CopyBackupCrossRegionRequest": {
-        "type": "object",
-        "properties": {
-          "destiny_region": {
-            "type": "string",
-            "title": "Destiny Region",
-            "maxLength": 255,
-            "minLength": 1
-          },
-          "backup": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "maxLength": 255,
-                    "minLength": 1
-                  }
-                ],
-                "title": "Id",
-                "nullable": true
-              },
-              "name": {
-                "anyOf": [
-                  {
-                    "type": "string",
-                    "maxLength": 255,
-                    "minLength": 1
-                  }
-                ],
-                "title": "Name",
-                "nullable": true
-              }
-            },
-            "title": "BackupIdRequest"
-          }
-        },
-        "title": "CopyBackupCrossRegionRequest",
-        "required": [
-          "destiny_region",
-          "backup"
-        ],
-        "example": {
-          "backup": {
-            "name": "backup-tomato"
-          },
-          "destiny_region": "br-ne1"
-        }
-      },
       "CopyCrossRegionRequest": {
         "type": "object",
         "properties": {
           "destination_region": {
             "type": "string",
-            "title": "Destination Region"
+            "title": "Regions",
+            "enum": [
+              "br-se1",
+              "br-mgl1",
+              "br-ne1"
+            ]
           }
         },
         "title": "CopyCrossRegionRequest",
@@ -2915,56 +1862,6 @@
           }
         }
       },
-      "CreateBackup": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              }
-            ],
-            "title": "Description",
-            "nullable": true
-          },
-          "volume": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/IdRequest"
-              },
-              {
-                "$ref": "#/components/schemas/Name"
-              }
-            ],
-            "title": "Volume"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "type": {
-            "type": "string",
-            "title": "BackupType",
-            "enum": [
-              "full",
-              "incremental"
-            ]
-          }
-        },
-        "title": "CreateBackup",
-        "required": [
-          "volume",
-          "name"
-        ],
-        "example": {
-          "description": "my-backup",
-          "name": "backup name",
-          "type": "full",
-          "volume": {
-            "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-          }
-        }
-      },
       "DiskType": {
         "type": "string",
         "title": "DiskType",
@@ -3001,129 +1898,11 @@
           "slug": "generic"
         }
       },
-      "ExpandBackup": {
-        "type": "string",
-        "title": "ExpandBackup",
-        "enum": [
-          "volume"
-        ]
-      },
       "ExpandSnapshots": {
         "type": "string",
         "title": "ExpandSnapshots",
         "enum": [
           "volume"
-        ]
-      },
-      "ExpandedVolume": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "title": "Id"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "state": {
-            "type": "string",
-            "title": "VolumeStateV1",
-            "enum": [
-              "new",
-              "available",
-              "in-use",
-              "deleted",
-              "legacy"
-            ]
-          },
-          "status": {
-            "type": "string",
-            "title": "VolumeStatusV1",
-            "enum": [
-              "provisioning",
-              "creating",
-              "creating_error",
-              "creating_error_quota",
-              "completed",
-              "extend_pending",
-              "extending",
-              "extend_error",
-              "extend_error_quota",
-              "attaching_pending",
-              "attaching_error",
-              "attaching",
-              "detaching_pending",
-              "detaching_error",
-              "detaching",
-              "retype_pending",
-              "retyping",
-              "retype_error",
-              "retype_error_quota",
-              "deleting_pending",
-              "deleting",
-              "deleted",
-              "deleted_error"
-            ]
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "title": "Created At",
-            "example": "2022-01-01T00:00:10Z"
-          },
-          "updated_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string",
-                "format": "date-time"
-              }
-            ],
-            "title": "Updated At",
-            "example": "2022-01-01T00:00:10Z"
-          },
-          "volume_type": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string",
-                "title": "Id",
-                "minLength": 1
-              }
-            },
-            "title": "IdResponse",
-            "required": [
-              "id"
-            ],
-            "example": {
-              "id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-            }
-          }
-        },
-        "title": "ExpandedVolume",
-        "required": [
-          "id",
-          "name",
-          "state",
-          "status",
-          "size",
-          "created_at",
-          "updated_at",
-          "volume_type"
         ]
       },
       "GenericVolumeTypeList_VolumeTypeResponseWithAzs_": {
@@ -3193,6 +1972,11 @@
                     "type": "string"
                   },
                   "title": "Availability Zones"
+                },
+                "allows_encryption": {
+                  "type": "boolean",
+                  "title": "Allows Encryption",
+                  "default": false
                 }
               },
               "title": "VolumeTypeResponseWithAzs",
@@ -3205,6 +1989,7 @@
                 "availability_zones"
               ],
               "example": {
+                "allows_encryption": true,
                 "availability_zones": [
                   "a"
                 ],
@@ -3229,6 +2014,7 @@
         "example": {
           "types": [
             {
+              "allows_encryption": true,
               "availability_zones": [
                 "a"
               ],
@@ -3379,37 +2165,14 @@
           "name": "some_resource_name"
         }
       },
-      "PatchResourceRequest": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              }
-            ],
-            "title": "Name",
-            "nullable": true
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              }
-            ],
-            "title": "Description",
-            "nullable": true
-          }
-        },
-        "title": "PatchResourceRequest",
-        "example": {
-          "description": "new description to my resource",
-          "name": "new name to my resource"
-        }
+      "Regions": {
+        "type": "string",
+        "title": "Regions",
+        "enum": [
+          "br-se1",
+          "br-mgl1",
+          "br-ne1"
+        ]
       },
       "RenameVolumeRequest": {
         "type": "object",
@@ -4060,6 +2823,12 @@
             ],
             "title": "Snapshot",
             "nullable": true
+          },
+          "encrypted": {
+            "type": "boolean",
+            "title": "Encrypted",
+            "description": "Indicates if the volume is encrypted. Default is False.",
+            "default": false
           }
         },
         "title": "VolumeCreateRequestV1",
@@ -4070,6 +2839,7 @@
         ],
         "example": {
           "availability_zone": "br-se1-a",
+          "encrypted": false,
           "name": "volume-name",
           "size": 10,
           "snapshot": {
@@ -4238,6 +3008,11 @@
               "type": "string"
             },
             "title": "Availability Zones"
+          },
+          "encrypted": {
+            "type": "boolean",
+            "title": "Encrypted",
+            "default": false
           }
         },
         "title": "VolumeResponseV1",
@@ -4271,6 +3046,7 @@
             "br-ne1-a"
           ],
           "created_at": "2022-01-01T00:00:10Z",
+          "encrypted": false,
           "error": {
             "message": "You have reached the limit of allowed disks. Please, remove unused disks or contact support to increase your quota.",
             "slug": "creating_error_quota"
@@ -4490,6 +3266,11 @@
               "type": "string"
             },
             "title": "Availability Zones"
+          },
+          "allows_encryption": {
+            "type": "boolean",
+            "title": "Allows Encryption",
+            "default": false
           }
         },
         "title": "VolumeTypeResponseWithAzs",
@@ -4502,6 +3283,7 @@
           "availability_zones"
         ],
         "example": {
+          "allows_encryption": true,
           "availability_zones": [
             "a"
           ],
@@ -4676,6 +3458,11 @@
                     "type": "string"
                   },
                   "title": "Availability Zones"
+                },
+                "encrypted": {
+                  "type": "boolean",
+                  "title": "Encrypted",
+                  "default": false
                 }
               },
               "title": "VolumeResponseV1",
@@ -4709,6 +3496,7 @@
                   "br-ne1-a"
                 ],
                 "created_at": "2022-01-01T00:00:10Z",
+                "encrypted": false,
                 "error": {
                   "message": "You have reached the limit of allowed disks. Please, remove unused disks or contact support to increase your quota.",
                   "slug": "creating_error_quota"
@@ -4751,6 +3539,7 @@
                 "br-ne1-a"
               ],
               "created_at": "2022-01-01T00:00:10Z",
+              "encrypted": false,
               "error": {
                 "message": "You have reached the limit of allowed disks. Please, remove unused disks or contact support to increase your quota.",
                 "slug": "creating_error_quota"

--- a/mgc/terraform-provider-mgc/docs/data-sources/block_storage_volume.md
+++ b/mgc/terraform-provider-mgc/docs/data-sources/block_storage_volume.md
@@ -39,6 +39,7 @@ output "my-volume" {
 - `availability_zone` (String) The availability zones where the block storage is available.
 - `created_at` (String) The timestamp when the block storage was created.
 - `disk_type` (String) The disk type of the block storage.
+- `encrypted` (Boolean) The encryption status of the block storage.
 - `name` (String) The name of the block storage.
 - `size` (Number) The size of the block storage in GB.
 - `state` (String) The current state of the virtual machine instance.

--- a/mgc/terraform-provider-mgc/docs/data-sources/block_storage_volumes.md
+++ b/mgc/terraform-provider-mgc/docs/data-sources/block_storage_volumes.md
@@ -36,6 +36,7 @@ Read-Only:
 
 - `availability_zone` (String) The availability zones where the block storage is available.
 - `created_at` (String) The timestamp when the block storage was created.
+- `encrypted` (Boolean) The encryption status of the block storage.
 - `id` (String) The unique identifier of the volume snapshot.
 - `name` (String) The name of the block storage.
 - `size` (Number) The size of the block storage in GB.

--- a/mgc/terraform-provider-mgc/docs/resources/block_storage_volumes.md
+++ b/mgc/terraform-provider-mgc/docs/resources/block_storage_volumes.md
@@ -33,6 +33,7 @@ resource "mgc_block_storage_volumes" "example_volume" {
 ### Optional
 
 - `availability_zone` (String) The availability zones where the volume is available.
+- `encrypted` (Boolean) Indicates if the volume is encrypted.
 - `snapshot_id` (String) Create a volume from a snapshot.
 
 ### Read-Only

--- a/mgc/terraform-provider-mgc/go.mod
+++ b/mgc/terraform-provider-mgc/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	magalu.cloud/lib v0.0.0-00010101000000-000000000000
-	magalu.cloud/sdk v0.31.0
+	magalu.cloud/sdk v0.32.0
 )
 
 require (
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
-	magalu.cloud/core v0.31.0 // indirect
+	magalu.cloud/core v0.32.0 // indirect
 )
 
 require (

--- a/mgc/terraform-provider-mgc/mgc/datasources/mgc_bs_volume.go
+++ b/mgc/terraform-provider-mgc/mgc/datasources/mgc_bs_volume.go
@@ -45,6 +45,7 @@ type bsVolumeResourceModel struct {
 	AttachedDevice       types.String `tfsdk:"attached_device"`
 	AttachedInstanceId   types.String `tfsdk:"attached_instance_id"`
 	AttachedInstanceName types.String `tfsdk:"attached_instance_name"`
+	Encrypted            types.Bool   `tfsdk:"encrypted"`
 }
 
 func (r *DataSourceBsVolume) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -134,6 +135,10 @@ func (r *DataSourceBsVolume) Schema(_ context.Context, req datasource.SchemaRequ
 				Description: "The name of the instance.",
 				Computed:    true,
 			},
+			"encrypted": schema.BoolAttribute{
+				Description: "The encryption status of the block storage.",
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -166,6 +171,7 @@ func (r *DataSourceBsVolume) Read(ctx context.Context, req datasource.ReadReques
 	data.TypeStatus = types.StringPointerValue(sdkOutput.Type.Status)
 	data.State = types.StringValue(sdkOutput.State)
 	data.Status = types.StringValue(sdkOutput.Status)
+	data.Encrypted = types.BoolPointerValue(sdkOutput.Encrypted)
 	if sdkOutput.Attachment != nil {
 		data.AttachedAt = types.StringValue(sdkOutput.Attachment.AttachedAt)
 		data.AttachedDevice = types.StringPointerValue(sdkOutput.Attachment.Device)

--- a/mgc/terraform-provider-mgc/mgc/datasources/mgc_bs_volumes.go
+++ b/mgc/terraform-provider-mgc/mgc/datasources/mgc_bs_volumes.go
@@ -30,6 +30,7 @@ type bsVolumesResourceItemModel struct {
 	TypeId           types.String `tfsdk:"type_id"`
 	State            types.String `tfsdk:"state"`
 	Status           types.String `tfsdk:"status"`
+	Encrepted        types.Bool   `tfsdk:"encrypted"`
 }
 
 func NewDataSourceBsVolumes() datasource.DataSource {
@@ -107,6 +108,10 @@ func (r *DataSourceBsVolumes) Schema(_ context.Context, req datasource.SchemaReq
 							Description: "The unique identifier of the block storage type.",
 							Computed:    true,
 						},
+						"encrypted": schema.BoolAttribute{
+							Description: "The encryption status of the block storage.",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -141,6 +146,7 @@ func (r *DataSourceBsVolumes) Read(ctx context.Context, req datasource.ReadReque
 		item.TypeId = types.StringPointerValue(sdkOutput.Type.Id)
 		item.State = types.StringValue(sdkOutput.State)
 		item.Status = types.StringValue(sdkOutput.Status)
+		item.Encrepted = types.BoolPointerValue(sdkOutput.Encrypted)
 
 		data.Volumes = append(data.Volumes, item)
 	}

--- a/mgc/terraform-provider-mgc/tests/block-storage/main.tf
+++ b/mgc/terraform-provider-mgc/tests/block-storage/main.tf
@@ -2,6 +2,7 @@ resource "mgc_block_storage_volumes" "example_volume" {
   name              = "example-volume"
   availability_zone = "br-ne1-a"
   size              = 200
+  encrypted         = true
   type              = "cloud_nvme1k"
 }
 
@@ -35,6 +36,13 @@ data "mgc_block_storage_snapshot" "snapshot_data" {
   id = mgc_block_storage_snapshots.snapshot_example.id
 
   depends_on = [mgc_block_storage_snapshots.snapshot_example]
+}
+
+data "mgc_block_storage_volumes" "volumes_data" {
+}
+
+output "name" {
+  value = data.mgc_block_storage_volumes.volumes_data
 }
 
 output "volume_details" {


### PR DESCRIPTION
## What does this PR do?
add encryption support for block storage volumes

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
  <!-- Example: Added unit tests for the new order history endpoint. All tests passed successfully. -->

- **Integration Tests**: Detail the integration tests performed and their results.
  <!-- Example: Performed integration tests with the payment service to ensure end-to-end functionality. All tests passed. -->

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
  <!-- Example: Manually tested the new endpoint using Postman. Verified that the correct order history is returned for different users. Attached screenshots of the Postman results. -->

```shell
❯ tfa -auto-approve
data.mgc_block_storage_volumes.volumes_data: Reading...
data.mgc_block_storage_volumes.volumes_data: Read complete after 1s

Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.mgc_block_storage_snapshot.snapshot_data will be read during apply
  # (config refers to values not yet known)
 <= data "mgc_block_storage_snapshot" "snapshot_data" {
      + availability_zones = (known after apply)
      + created_at         = (known after apply)
      + description        = (known after apply)
      + id                 = (known after apply)
      + name               = (known after apply)
      + size               = (known after apply)
      + state              = (known after apply)
      + status             = (known after apply)
      + type               = (known after apply)
      + updated_at         = (known after apply)
      + volume_id          = (known after apply)
    }

  # data.mgc_block_storage_volume.volume_data will be read during apply
  # (config refers to values not yet known)
 <= data "mgc_block_storage_volume" "volume_data" {
      + attached_at            = (known after apply)
      + attached_device        = (known after apply)
      + attached_instance_id   = (known after apply)
      + attached_instance_name = (known after apply)
      + availability_zone      = (known after apply)
      + created_at             = (known after apply)
      + disk_type              = (known after apply)
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + name                   = (known after apply)
      + size                   = (known after apply)
      + state                  = (known after apply)
      + status                 = (known after apply)
      + type_id                = (known after apply)
      + type_name              = (known after apply)
      + type_status            = (known after apply)
      + updated_at             = (known after apply)
    }

  # mgc_block_storage_snapshots.snapshot_example will be created
  + resource "mgc_block_storage_snapshots" "snapshot_example" {
      + created_at  = (known after apply)
      + description = "Example snapshot description"
      + id          = (known after apply)
      + name        = "snapshot-example"
      + type        = "instant"
      + volume_id   = (known after apply)
    }

  # mgc_block_storage_volume_attachment.example_attachment will be created
  + resource "mgc_block_storage_volume_attachment" "example_attachment" {
      + block_storage_id   = (known after apply)
      + virtual_machine_id = (known after apply)
    }

  # mgc_block_storage_volumes.example_volume will be created
  + resource "mgc_block_storage_volumes" "example_volume" {
      + availability_zone = "br-ne1-a"
      + created_at        = (known after apply)
      + encrypted         = true
      + id                = (known after apply)
      + name              = "example-volume"
      + size              = 200
      + type              = "cloud_nvme1k"
    }

  # mgc_virtual_machine_instances.basic_instance will be created
  + resource "mgc_virtual_machine_instances" "basic_instance" {
      + availability_zone  = (known after apply)
      + created_at         = (known after apply)
      + id                 = (known after apply)
      + image              = "cloud-ubuntu-24.04 LTS"
      + machine_type       = "cloud-bs1.xsmall"
      + name               = "basic-instance-test-smoke"
      + network_interfaces = (known after apply)
      + ssh_key_name       = "publio"
      + vpc_id             = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + name             = {
      + volumes = null
    }
  + snapshot_details = {
      + availability_zones = (known after apply)
      + created_at         = (known after apply)
      + description        = (known after apply)
      + id                 = (known after apply)
      + name               = (known after apply)
      + size               = (known after apply)
      + state              = (known after apply)
      + status             = (known after apply)
      + type               = (known after apply)
      + updated_at         = (known after apply)
      + volume_id          = (known after apply)
    }
  + volume_details   = {
      + attached_at            = (known after apply)
      + attached_device        = (known after apply)
      + attached_instance_id   = (known after apply)
      + attached_instance_name = (known after apply)
      + availability_zone      = (known after apply)
      + created_at             = (known after apply)
      + disk_type              = (known after apply)
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + name                   = (known after apply)
      + size                   = (known after apply)
      + state                  = (known after apply)
      + status                 = (known after apply)
      + type_id                = (known after apply)
      + type_name              = (known after apply)
      + type_status            = (known after apply)
      + updated_at             = (known after apply)
    }
mgc_virtual_machine_instances.basic_instance: Creating...
mgc_block_storage_volumes.example_volume: Creating...
mgc_virtual_machine_instances.basic_instance: Still creating... [10s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [10s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [20s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [20s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [30s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [30s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [40s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [40s elapsed]
mgc_virtual_machine_instances.basic_instance: Still creating... [50s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [50s elapsed]
mgc_virtual_machine_instances.basic_instance: Creation complete after 51s [id=6786f0f4-22f2-4e90-9232-e5f3e0b18bb6]
mgc_block_storage_volumes.example_volume: Still creating... [1m0s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [1m10s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [1m20s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [1m30s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [1m40s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [1m50s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [2m0s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [2m10s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [2m20s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [2m30s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [2m40s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [2m50s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [3m0s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [3m10s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [3m20s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [3m30s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [3m40s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [3m50s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [4m0s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [4m10s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [4m20s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [4m30s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [4m40s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [4m50s elapsed]
mgc_block_storage_volumes.example_volume: Still creating... [5m0s elapsed]
mgc_block_storage_volumes.example_volume: Creation complete after 5m3s [id=81d196d8-692e-462d-9daa-5d0fae7e64a0]
data.mgc_block_storage_volume.volume_data: Reading...
mgc_block_storage_volume_attachment.example_attachment: Creating...
data.mgc_block_storage_volume.volume_data: Read complete after 1s [id=81d196d8-692e-462d-9daa-5d0fae7e64a0]
mgc_block_storage_volume_attachment.example_attachment: Still creating... [10s elapsed]
mgc_block_storage_volume_attachment.example_attachment: Creation complete after 13s
mgc_block_storage_snapshots.snapshot_example: Creating...
mgc_block_storage_snapshots.snapshot_example: Still creating... [10s elapsed]
mgc_block_storage_snapshots.snapshot_example: Creation complete after 12s [id=90e6623e-1a57-4085-85be-d20091390f77]
data.mgc_block_storage_snapshot.snapshot_data: Reading...
data.mgc_block_storage_snapshot.snapshot_data: Read complete after 1s [id=90e6623e-1a57-4085-85be-d20091390f77]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

```

```shell
Outputs:

name = {
  "volumes" = tolist([
    {
      "availability_zone" = "br-ne1-a"
      "created_at" = "2025-01-16T13:53:47Z"
      "encrypted" = true
      "id" = "81d196d8-692e-462d-9daa-5d0fae7e64a0"
      "name" = "example-volume"
      "size" = 200
      "state" = "in-use"
      "status" = "completed"
      "type_id" = "ca6502c4-0782-4add-9d71-7e8c13bd10ee"
      "updated_at" = "2025-01-16T13:58:58Z"
    },
  ])
}
snapshot_details = {
  "availability_zones" = tolist([
    "br-ne1-a",
  ])
  "created_at" = "2025-01-16T13:59:02Z"
  "description" = "Example snapshot description"
  "id" = "90e6623e-1a57-4085-85be-d20091390f77"
  "name" = "snapshot-example"
  "size" = 200
  "state" = "available"
  "status" = "completed"
  "type" = "instant"
  "updated_at" = "2025-01-16T14:02:06Z"
  "volume_id" = "81d196d8-692e-462d-9daa-5d0fae7e64a0"
}
volume_details = {
  "attached_at" = "2025-01-16T13:58:50Z"
  "attached_device" = "/dev/vdb"
  "attached_instance_id" = "6786f0f4-22f2-4e90-9232-e5f3e0b18bb6"
  "attached_instance_name" = "basic-instance-test-smoke"
  "availability_zone" = "br-ne1-a"
  "created_at" = "2025-01-16T13:53:47Z"
  "disk_type" = "nvme"
  "encrypted" = true
  "id" = "81d196d8-692e-462d-9daa-5d0fae7e64a0"
  "name" = "example-volume"
  "size" = 200
  "state" = "in-use"
  "status" = "completed"
  "type_id" = "ca6502c4-0782-4add-9d71-7e8c13bd10ee"
  "type_name" = "cloud_nvme1k"
  "type_status" = "active"
  "updated_at" = "2025-01-16T13:58:58Z"
}

terraform-provider-mgc/tests/block-storage on  block-storage-encrypted [$+] via  v3.12.7 (magalu-py3.12) via 💠 default on 󱒕 mgc-dev (br-ne1) took 15s
❯ tfa
mgc_block_storage_volumes.example_volume: Refreshing state... [id=81d196d8-692e-462d-9daa-5d0fae7e64a0]
mgc_virtual_machine_instances.basic_instance: Refreshing state... [id=6786f0f4-22f2-4e90-9232-e5f3e0b18bb6]
data.mgc_block_storage_volumes.volumes_data: Reading...
data.mgc_block_storage_volume.volume_data: Reading...
data.mgc_block_storage_volumes.volumes_data: Read complete after 2s
mgc_block_storage_volume_attachment.example_attachment: Refreshing state...
data.mgc_block_storage_volume.volume_data: Read complete after 2s [id=81d196d8-692e-462d-9daa-5d0fae7e64a0]
mgc_block_storage_snapshots.snapshot_example: Refreshing state... [id=90e6623e-1a57-4085-85be-d20091390f77]
data.mgc_block_storage_snapshot.snapshot_data: Reading...
data.mgc_block_storage_snapshot.snapshot_data: Read complete after 0s [id=90e6623e-1a57-4085-85be-d20091390f77]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no
changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

name = {
  "volumes" = tolist([
    {
      "availability_zone" = "br-ne1-a"
      "created_at" = "2025-01-16T13:53:47Z"
      "encrypted" = true
      "id" = "81d196d8-692e-462d-9daa-5d0fae7e64a0"
      "name" = "example-volume"
      "size" = 200
      "state" = "in-use"
      "status" = "completed"
      "type_id" = "ca6502c4-0782-4add-9d71-7e8c13bd10ee"
      "updated_at" = "2025-01-16T13:58:58Z"
    },
  ])
}
snapshot_details = {
  "availability_zones" = tolist([
    "br-ne1-a",
  ])
  "created_at" = "2025-01-16T13:59:02Z"
  "description" = "Example snapshot description"
  "id" = "90e6623e-1a57-4085-85be-d20091390f77"
  "name" = "snapshot-example"
  "size" = 200
  "state" = "available"
  "status" = "completed"
  "type" = "instant"
  "updated_at" = "2025-01-16T14:02:06Z"
  "volume_id" = "81d196d8-692e-462d-9daa-5d0fae7e64a0"
}
volume_details = {
  "attached_at" = "2025-01-16T13:58:50Z"
  "attached_device" = "/dev/vdb"
  "attached_instance_id" = "6786f0f4-22f2-4e90-9232-e5f3e0b18bb6"
  "attached_instance_name" = "basic-instance-test-smoke"
  "availability_zone" = "br-ne1-a"
  "created_at" = "2025-01-16T13:53:47Z"
  "disk_type" = "nvme"
  "encrypted" = true
  "id" = "81d196d8-692e-462d-9daa-5d0fae7e64a0"
  "name" = "example-volume"
  "size" = 200
  "state" = "in-use"
  "status" = "completed"
  "type_id" = "ca6502c4-0782-4add-9d71-7e8c13bd10ee"
  "type_name" = "cloud_nvme1k"
  "type_status" = "active"
  "updated_at" = "2025-01-16T13:58:58Z"
}

```

```shell
./mgc block-storage volumes create --help   
Create a Volume for the currently authenticated tenant.

The Volume can be used when it reaches the "available" state and "completed"
 status.

#### Rules
- The Volume name must be unique; otherwise, the creation will be disallowed.
- The Volume type must be available to use.

#### Notes
- Utilize the **block-storage volume-types list** command to retrieve a list
 of all available Volume Types.
- Verify the state and status of your Volume using the
**block-storage volume get --id [uuid]** command".

Usage:
  ./mgc block-storage volumes create [flags]

Examples:
  ./mgc block-storage volumes create --snapshot.id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" --snapshot.name="some_resource_name" --type.id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" --type.name="some_resource_name"

Flags:
      --availability-zone string      Availability Zone
      --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
      --encrypted                     Indicates if the volume is encrypted. Default is False.
  -h, --help                          help for create
      --name string                   Name (between 3 and 50 characters) (required)
      --size integer                  Size: Gibibytes (GiB) (range: 10 - 2147483648) (required)
      --snapshot object               Snapshot (at least one of: single property: id or single property: name)
                                      Use --snapshot=help for more details
      --snapshot.id string            Snapshot: Id (min character count: 1)
                                      This is the same as '--snapshot=id:string'.
      --snapshot.name string          Snapshot: Name (between 1 and 255 characters)
                                      This is the same as '--snapshot=name:string'.
      --type object                   Type (at least one of: single property: id or single property: name)
                                      Use --type=help for more details (required)
      --type.id string                Type: Id (min character count: 1)
                                      This is the same as '--type=id:string'.
      --type.name string              Type: Name (between 1 and 255 characters)
                                      This is the same as '--type=name:string'.
  -v, --version                       version for create

Global Flags:
      --api-key string           Use your API key to authenticate with the API
  -U, --cli.retry-until string   Retry the action with the same parameters until the given condition is met. The flag parameters
                                 use the format: 'retries,interval,condition', where 'retries' is a positive integer, 'interval' is
                                 a duration (ex: 2s) and 'condition' is a 'engine=value' pair such as "jsonpath=expression"
  -t, --cli.timeout duration     If > 0, it's the timeout for the action execution. It's specified as numbers and unit suffix.
                                 Valid unit suffixes: ns, us, ms, s, m and h. Examples: 300ms, 1m30s
      --debug                    Display detailed log information at the debug level
      --env enum                 Environment to use (one of "pre-prod" or "prod") (default "prod")
      --no-confirm               Bypasses confirmation step for commands that ask a confirmation from the user
  -o, --output string            Change the output format. Use '--output=help' to know more details.
  -r, --raw                      Output raw data, without any formatting or coloring
      --region enum              Region to reach the service (one of "br-mgl1", "br-ne1" or "br-se1") (default "br-se1")
      --server-url uri           Manually specify the server to use
```



## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->