### PR TITLE
chore: upgrade precommit to v5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         stages: [pre-commit]
         require_serial: true
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
         stages: [pre-commit, pre-push]


### PR DESCRIPTION
```shell
❯ g commit -m 'chore: upgrade precommit to v5'
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check "cli dump-tree" output.............................................Passed
check "cli doc" outputs..................................................Passed
apply-oapi-customizations................................................Passed
oapi-index-gen...........................................................Passed
generate terraform documentation.........................................Passed
check terraform examples.................................................Passed
check terraform documentation subcategory................................Passed
check openapi links......................................................Passed
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
check yaml...............................................................Passed
check for added large files..............................................Passed
check that scripts with shebangs are executable..........................Passed
check for merge conflicts................................................Passed
mixed line ending........................................................Passed
golangci-lint........................................(no files to check)Skipped
go-mod-tidy..........................................(no files to check)Skipped
flake8...............................................(no files to check)Skipped
black................................................(no files to check)Skipped
```