### PR TITLE
fix: handling of availability zones for block storage volumes

### DIFF
--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
@@ -189,9 +189,9 @@ func (r *bsVolumes) Create(ctx context.Context, req resource.CreateRequest, resp
 	}
 
 	createParam := sdkBlockStorageVolumes.CreateParameters{
-		Name:             state.Name.ValueString(),
-		Size:             int(state.Size.ValueInt64()),
-		Encrypted:        state.Encrypted.ValueBoolPointer(),
+		Name:      state.Name.ValueString(),
+		Size:      int(state.Size.ValueInt64()),
+		Encrypted: state.Encrypted.ValueBoolPointer(),
 		Type: sdkBlockStorageVolumes.CreateParametersType{
 			Name: state.Type.ValueStringPointer(),
 		},

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
@@ -134,7 +134,6 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
-					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"size": schema.Int64Attribute{
@@ -193,7 +192,6 @@ func (r *bsVolumes) Create(ctx context.Context, req resource.CreateRequest, resp
 		Name:             state.Name.ValueString(),
 		Size:             int(state.Size.ValueInt64()),
 		Encrypted:        state.Encrypted.ValueBoolPointer(),
-		AvailabilityZone: state.AvailabilityZone.ValueStringPointer(),
 		Type: sdkBlockStorageVolumes.CreateParametersType{
 			Name: state.Type.ValueStringPointer(),
 		},
@@ -202,6 +200,9 @@ func (r *bsVolumes) Create(ctx context.Context, req resource.CreateRequest, resp
 		createParam.Snapshot = &sdkBlockStorageVolumes.CreateParametersSnapshot{
 			Id: state.SnapshotID.ValueStringPointer(),
 		}
+	}
+	if !state.AvailabilityZone.IsUnknown() {
+		createParam.AvailabilityZone = state.AvailabilityZone.ValueStringPointer()
 	}
 
 	createResult, err := r.bsVolumes.CreateContext(ctx, createParam,


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
<!--Example: This PR adds a new endpoint to the API that allows users to retrieve their order history. It includes the necessary changes to the controller, service, and repository layers, as well as updates to the API documentation. -->
When not passing a value for az in block storage volumes the sdk has sending the field with a empty value.

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
  <!-- Example: Added unit tests for the new order history endpoint. All tests passed successfully. -->

- **Integration Tests**: Detail the integration tests performed and their results.
  <!-- Example: Performed integration tests with the payment service to ensure end-to-end functionality. All tests passed. -->

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
  <!-- Example: Manually tested the new endpoint using Postman. Verified that the correct order history is returned for different users. Attached screenshots of the Postman results. -->

## Checklist
- [ ] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->