### PR TITLE
fix: terraform virtual machine vpc error, block storage recreation and network vpc creating with error

### DIFF
--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_bs_volumes.go
@@ -134,6 +134,7 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"size": schema.Int64Attribute{
@@ -156,7 +157,8 @@ func (r *bsVolumes) Schema(_ context.Context, _ resource.SchemaRequest, resp *re
 				Computed:    true,
 				Optional:    true,
 				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.RequiresReplace(),
+					tfutil.ReplaceIfChangeAndNotIsNotSetOnPlanBool{},
+					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 		},

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_net_vpcs.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_net_vpcs.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	mgcSdk "github.com/MagaluCloud/magalu/mgc/lib"
@@ -110,6 +111,10 @@ func (r *NetworkVPCResource) Create(ctx context.Context, req resource.CreateRequ
 		}
 		if res.Status == "created" {
 			break
+		}
+		if strings.Contains(res.Status, "error") {
+			resp.Diagnostics.AddError("Error in VPC creation", res.Status)
+			return
 		}
 		tflog.Info(ctx, "VPC is not yet created, waiting for 10 seconds",
 			map[string]interface{}{"status": res.Status})

--- a/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_instances.go
+++ b/mgc/terraform-provider-mgc/mgc/resources/mgc_vm_instances.go
@@ -285,8 +285,10 @@ func (r *vmInstances) Create(ctx context.Context, req resource.CreateRequest, re
 		},
 	}
 
-	if !state.VpcId.IsUnknown() {
-		createParams.Network.Vpc.Id = state.VpcId.ValueString()
+	if state.VpcId.ValueString() != "" {
+		createParams.Network.Vpc = &sdkVmInstances.CreateParametersNetworkVpc{
+			Id: state.VpcId.ValueString(),
+		}
 	}
 
 	createdId, err := r.vmInstances.CreateContext(ctx, createParams, tfutil.GetConfigsFromTags(r.sdkClient.Sdk().Config().Get, sdkVmInstances.CreateConfigs{}))

--- a/mgc/terraform-provider-mgc/mgc/tfutil/planmodifiers.go
+++ b/mgc/terraform-provider-mgc/mgc/tfutil/planmodifiers.go
@@ -27,3 +27,25 @@ func (p ReplaceIfChangeAndNotIsNotSetOnPlan) Description(context.Context) string
 func (p ReplaceIfChangeAndNotIsNotSetOnPlan) MarkdownDescription(context.Context) string {
 	return "Requires replace if the value is different from the state and the plan value is not unknown."
 }
+
+type ReplaceIfChangeAndNotIsNotSetOnPlanBool struct{}
+
+func (p ReplaceIfChangeAndNotIsNotSetOnPlanBool) PlanModifyBool(ctx context.Context, request planmodifier.BoolRequest, response *planmodifier.BoolResponse) {
+	if request.PlanValue.IsUnknown() {
+		response.RequiresReplace = false
+		return
+	}
+	if !request.StateValue.Equal(request.PlanValue) {
+		response.RequiresReplace = true
+		return
+	}
+	response.RequiresReplace = false
+}
+
+func (p ReplaceIfChangeAndNotIsNotSetOnPlanBool) Description(context.Context) string {
+	return "Requires replace if the value is different from the state and the plan value is not unknown."
+}
+
+func (p ReplaceIfChangeAndNotIsNotSetOnPlanBool) MarkdownDescription(context.Context) string {
+	return "Requires replace if the value is different from the state and the plan value is not unknown."
+}


### PR DESCRIPTION
## What does this PR do?

* Added error handling for VPC creation in `mgc_net_vpcs.go` to capture and log errors when the VPC creation status contains "error".

* Updated `mgc_bs_volumes.go` to include a custom plan modifier `ReplaceIfChangeAndNotIsNotSetOnPlanBool` for boolean attributes.

* Modified the VM instance creation logic in `mgc_vm_instances.go` to check if `VpcId` is not an empty string before setting the network VPC ID.

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
  <!-- Example: Added unit tests for the new order history endpoint. All tests passed successfully. -->

- **Integration Tests**: Detail the integration tests performed and their results.
  <!-- Example: Performed integration tests with the payment service to ensure end-to-end functionality. All tests passed. -->

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
  <!-- Example: Manually tested the new endpoint using Postman. Verified that the correct order history is returned for different users. Attached screenshots of the Postman results. -->

## Checklist
- [ ] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->