### PR TITLE
chore: add local build target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,5 @@ build-spec:
 	cd mgc/cli; echo "Building...."; \
 	go build -tags "embed" -o mgc
 
-build:
-	cd mgc/cli; echo "Building...."; \
-	go build -tags "embed" -o mgc
+build-local:
+	goreleaser build --clean --snapshot --single-target -f goreleaser_cli.yaml

--- a/README.md
+++ b/README.md
@@ -29,9 +29,20 @@ install, visit the official link with the instructions.
 There are some utility scripts written in [Python](https://www.python.org/downloads/).
 For this, [Poetry](https://python-poetry.org/) is used. Check [Poetry.md](Poetry.md) for instructions.
 
-## Running the CLI
+## Building and running locally
 
-See [cli/RUNNING.md](./mgc/cli/RUNNING.md)
+Building needs [goreleaser](https://goreleaser.com/install/) and can be done using a Makefile target:
+
+```bash
+$ make build-local
+```
+
+If all goes well, the output binary will be a platform-dependent directory, where it can be run:
+
+```bash
+$ cd dist/mgc_<your_platform>
+$ ./mgc
+```
 
 ## OpenAPI
 


### PR DESCRIPTION
## What does this PR do?
Creates a easy-to-use Makefile target for local builds.
Useful for people trying branches and pre-releases (snapshots) locally.

## How Has This Been Tested?
- **Manual Testing**: Build a local version following new README instructions.


## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
![image](https://github.com/user-attachments/assets/bd834636-857c-4955-a079-b23c939feb7a)