### PR TITLE
Update machine type listing

### DIFF
--- a/mgc/cli/docs/virtual-machine/instances/list.md
+++ b/mgc/cli/docs/virtual-machine/instances/list.md
@@ -9,7 +9,7 @@ mgc virtual-machine instances list [flags]
 
 ## Flags:
 ```
-    --control.limit integer     Limit: limit the number of the results (max: 1000) (default 50)
+    --control.limit integer     Limit: limit the number of the results (max: 1000) (default 200)
     --control.offset integer    Offset: pagination for the results limited (max: 2147483647)
     --control.sort string       Sort: order of the results using informed fields (pattern: ^(^[\w-]+:(asc|desc)(,[\w-]+:(asc|desc))*)?$) (default "created_at:asc")
     --expand array(string)     Expand: You can get more detailed info about: ['image', 'machine-type', 'machine-types', 'network', 'labels']  (default [])

--- a/mgc/cli/docs/virtual-machine/machine-types/list.md
+++ b/mgc/cli/docs/virtual-machine/machine-types/list.md
@@ -10,7 +10,7 @@ mgc virtual-machine machine-types list [flags]
 ## Flags:
 ```
     --availability-zone string   Availability-Zone: br-ne1-a
-    --control.limit integer       Limit: limit the number of the results (max: 1000) (default 50)
+    --control.limit integer       Limit: limit the number of the results (max: 1000) (default 200)
     --control.offset integer      Offset: pagination for the results limited (max: 2147483647)
     --control.sort string         Sort: order of the results using informed fields (pattern: ^(^[\w-]+:(asc|desc)(,[\w-]+:(asc|desc))*)?$) (default "created_at:asc")
 -h, --help                       help for list

--- a/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
@@ -1349,7 +1349,6 @@ paths:
             parameters:
             -   name: _limit
                 in: query
-                description: limit the number of the results
                 required: false
                 schema:
                     exclusiveMinimum: false
@@ -1357,7 +1356,8 @@ paths:
                     title: ' Limit'
                     maximum: 1000
                     description: limit the number of the results
-                    default: 50
+                    default: 200
+                description: limit the number of the results
             -   name: _offset
                 in: query
                 description: pagination for the results limited

--- a/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
@@ -86,7 +86,6 @@ paths:
             parameters:
             -   name: _limit
                 in: query
-                description: limit the number of the results
                 required: false
                 schema:
                     exclusiveMinimum: false
@@ -94,7 +93,8 @@ paths:
                     title: ' Limit'
                     maximum: 1000
                     description: limit the number of the results
-                    default: 50
+                    default: 200
+                description: limit the number of the results
             -   name: _offset
                 in: query
                 description: pagination for the results limited

--- a/specs/conv.virtual-machine.jaxyendy.openapi.json
+++ b/specs/conv.virtual-machine.jaxyendy.openapi.json
@@ -116,7 +116,6 @@
           {
             "name": "_limit",
             "in": "query",
-            "description": "limit the number of the results",
             "required": false,
             "schema": {
               "exclusiveMinimum": false,
@@ -124,8 +123,9 @@
               "title": " Limit",
               "maximum": 1000,
               "description": "limit the number of the results",
-              "default": 50
-            }
+              "default": 200
+            },
+            "description": "limit the number of the results"
           },
           {
             "name": "_offset",

--- a/specs/conv.virtual-machine.jaxyendy.openapi.json
+++ b/specs/conv.virtual-machine.jaxyendy.openapi.json
@@ -1216,7 +1216,6 @@
           {
             "name": "_limit",
             "in": "query",
-            "description": "limit the number of the results",
             "required": false,
             "schema": {
               "exclusiveMinimum": false,
@@ -1224,8 +1223,9 @@
               "title": " Limit",
               "maximum": 1000,
               "description": "limit the number of the results",
-              "default": 50
-            }
+              "default": 200
+            },
+            "description": "limit the number of the results"
           },
           {
             "name": "_offset",

--- a/specs/virtual-machine.jaxyendy.openapi.json
+++ b/specs/virtual-machine.jaxyendy.openapi.json
@@ -119,16 +119,16 @@
           {
             "name": "_limit",
             "in": "query",
-            "description": "limit the number of the results",
             "required": false,
             "schema": {
-              "exclusiveMinimum": 0,
               "type": "integer",
-              "title": " Limit",
               "maximum": 1000,
+              "exclusiveMinimum": true,
               "description": "limit the number of the results",
-              "default": 50
-            }
+              "default": 200,
+              "title": " Limit"
+            },
+            "description": "limit the number of the results"
           },
           {
             "name": "_offset",

--- a/specs/virtual-machine.jaxyendy.openapi.json
+++ b/specs/virtual-machine.jaxyendy.openapi.json
@@ -123,7 +123,7 @@
             "schema": {
               "type": "integer",
               "maximum": 1000,
-              "exclusiveMinimum": true,
+              "exclusiveMinimum": 0,
               "description": "limit the number of the results",
               "default": 200,
               "title": " Limit"
@@ -1224,16 +1224,16 @@
           {
             "name": "_limit",
             "in": "query",
-            "description": "limit the number of the results",
             "required": false,
             "schema": {
-              "exclusiveMinimum": 0,
               "type": "integer",
-              "title": " Limit",
               "maximum": 1000,
+              "exclusiveMinimum": 0,
               "description": "limit the number of the results",
-              "default": 50
-            }
+              "default": 200,
+              "title": " Limit"
+            },
+            "description": "limit the number of the results"
           },
           {
             "name": "_offset",


### PR DESCRIPTION
## What does this PR do?
Updates VM specs to reflect new default limit for machine types listing

## How Has This Been Tested?
Manual testing on machine-type listing:
```
🛠️  ./dist/mgc_linux_amd64_v1/mgc virtual-machine machine-types list
machine_types:                                                                                                                                                                                                                                                                              
- availability_zones:
  - br-se1-a
  - br-se1-b
  - br-se1-c
  disk: 150
  gpu: 0
  id: 3f1a9f2b-47db-4708-bf82-bea37b54bd4a
  name: BV4-16-150
  ram: 16384
  status: active
  vcpus: 4
...
- availability_zones:
  - br-se1-b
  - br-se1-c
  disk: 300
  gpu: 1
  id: 41852f29-46ef-4987-878f-d352a0f3e338
  name: L40x1-BV4-16-300
  ram: 16
  status: active
  vcpus: 4
meta:
    page:
        count: 62
        limit: 200
        offset: 0
        total: 62
```


## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->