### PR TITLE
change main.go - version output

### DIFF
--- a/mgc/cli/main.go
+++ b/mgc/cli/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"runtime"
 	"runtime/debug"
 	"strings"
@@ -17,12 +16,6 @@ var RawVersion string
 var Version string = func() string {
 	if RawVersion == "" {
 		return getVCSInfo("v0.0.0")
-	}
-
-	// Validate version format using regex
-	matched, err := regexp.MatchString(`^v\d+\.\d+\.\d+$`, RawVersion)
-	if err != nil || !matched {
-		return getVCSInfo(RawVersion)
 	}
 
 	return strings.Trim(RawVersion, " \t\n\r")


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
<!--Example: This PR adds a new endpoint to the API that allows users to retrieve their order history. It includes the necessary changes to the controller, service, and repository layers, as well as updates to the API documentation. -->

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
  <!-- Example: Added unit tests for the new order history endpoint. All tests passed successfully. -->

- **Integration Tests**: Detail the integration tests performed and their results.
  <!-- Example: Performed integration tests with the payment service to ensure end-to-end functionality. All tests passed. -->

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
  <!-- Example: Manually tested the new endpoint using Postman. Verified that the correct order history is returned for different users. Attached screenshots of the Postman results. -->

## Checklist
- [ ] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
Com versão:
![image](https://github.com/user-attachments/assets/18947565-d20c-4f7e-b8d0-2c6d16df7ccf)

Sem versão:
![image](https://github.com/user-attachments/assets/bd2fcb35-fc29-48fd-bdf0-0dae89c4842e)

Com `make build-local` - sem versão e sendo um snapshot:
![image](https://github.com/user-attachments/assets/b2a4c98f-5764-4f7f-9474-430a56fee9bb)
![image](https://github.com/user-attachments/assets/64a39f94-c576-4ea8-a34c-c0835e66f68f)

