### PR TITLE
chore: add windows build to internal goreleaser

### DIFF
--- a/internal.yaml
+++ b/internal.yaml
@@ -1,8 +1,7 @@
 project_name: mgccli
 version: 2
 builds:
-  -
-    env: [CGO_ENABLED=0]
+  - env: [CGO_ENABLED=0]
     id: "mgc"
     goos:
       - linux
@@ -15,6 +14,19 @@ builds:
       - -s -w -X main.RawVersion={{.Version}}
     flags:
       - -tags=embed -buildvcs=true
+    main: ./mgc/cli
+  - env: [CGO_ENABLED=0]
+    id: "mgcwin"
+    goos:
+      - windows
+    binary: mgc
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.RawVersion=v{{.Version}}
+    flags:
+      - -tags=embed release
     main: ./mgc/cli
 nfpms:
 -


### PR DESCRIPTION
## What does this PR do?
Add windows build to local build goreleaser config

## How Has This Been Tested?
Manually by developer. 

- Made a single-target build (`make build-local`) on linux, a linux binary was produced.
- Run goreleaser without single-target flag (`goreleaser build --clean --snapshot -f internal.yaml`) and all targets were produced, including windows binaries for arm64 and amd64

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
single-target:
![image](https://github.com/user-attachments/assets/d87cdea7-28d8-4828-8485-09f80570c402)

multi-target:
![image](https://github.com/user-attachments/assets/e6aa8d2b-ae91-4ddc-824e-0952bffdc518)
