### PR TITLE
(OBJS) normalize key when upload objects with backslash (windows default)

### DIFF
--- a/mgc/sdk/static/object_storage/common/path_utils.go
+++ b/mgc/sdk/static/object_storage/common/path_utils.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"net/url"
+	"strings"
+)
+
+// NormalizeFilePath normalizes file paths for consistent handling across different systems
+// It decodes URL-encoded characters, normalizes directory separators, and removes various prefixes
+func NormalizeFilePath(srcPath string) string {
+	decodedPath, err := url.PathUnescape(srcPath)
+	if err != nil {
+		decodedPath = srcPath
+	}	
+	normalizedPath := strings.ReplaceAll(decodedPath, "\\", "/")
+	normalizedPath = strings.TrimPrefix(normalizedPath, "path://")
+	normalizedPath = strings.TrimPrefix(normalizedPath, "./")
+	normalizedPath = strings.TrimPrefix(normalizedPath, ".")
+	
+	return normalizedPath
+}
+
+// ExtractFileName extracts just the filename from a path
+func ExtractFileName(path string) string {
+	normalizedPath := NormalizeFilePath(path)
+
+	var fileName string
+	if lastSlash := strings.LastIndex(normalizedPath, "/"); lastSlash >= 0 {
+		fileName = normalizedPath[lastSlash+1:]
+	} else {
+		fileName = normalizedPath
+	}
+	
+	return fileName
+}
+
+// GetRelativePath gets the relative path between a base path and a file path
+func GetRelativePath(basePath, filePath string) string {
+	normalizedBasePath := NormalizeFilePath(basePath)
+	normalizedFilePath := NormalizeFilePath(filePath)
+	
+	relPath := strings.TrimPrefix(normalizedFilePath, normalizedBasePath)
+	relPath = strings.TrimPrefix(relPath, "/")
+	
+	return relPath
+}

--- a/mgc/sdk/static/object_storage/objects/upload.go
+++ b/mgc/sdk/static/object_storage/objects/upload.go
@@ -42,7 +42,9 @@ func upload(ctx context.Context, params uploadParams, cfg common.Config) (*uploa
 		return nil, core.UsageError{Err: fmt.Errorf("destination cannot be empty")}
 	}
 
-	fileName := params.Source.AsURI().Filename()
+	srcPath := params.Source.AsURI().String()
+	fileName := common.ExtractFileName(srcPath)
+	
 	if params.Destination.IsRoot() || strings.HasSuffix(fullDstPath.String(), "/") {
 		fullDstPath = fullDstPath.JoinPath(fileName)
 	}

--- a/mgc/sdk/static/object_storage/objects/upload_dir.go
+++ b/mgc/sdk/static/object_storage/objects/upload_dir.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	syncer "sync"
 
 	"github.com/MagaluCloud/magalu/mgc/core"
@@ -86,7 +85,10 @@ func uploadDir(ctx context.Context, params uploadDirParams, cfg common.Config) (
 }
 
 func processFile(ctx context.Context, cfg common.Config, destination mgcSchemaPkg.URI, basePath string, storageClass string, file string, progressBar *pterm.ProgressbarPrinter) error {
-	dst := destination.JoinPath((strings.TrimPrefix(file, basePath)))
+	
+	relPath := common.GetRelativePath(basePath, file)
+	
+	dst := destination.JoinPath(relPath)
 
 	_, err := upload(
 		ctx,


### PR DESCRIPTION
## What does this PR do?
Quando é realizado um upload de um objeto via mgc cli, de um SO Windows, o objeto fica com partes do path e barras inversas na key.
<Key>.\barrainversamgccli.txt</Key>

isso afeta diretamente o list, pois para listar o objeto precisamos utilizar caracteres de escape, do tipo:
.%5Cbarrainversamgccli.txt

Com esse PR, ao fazer o upload de um Windows, a key é normalizada e o objeto é salvo com os padrões corretos de nome.

## How Has This Been Tested?
- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
Testes realizados utilizando os comandos da cli, para upload de objetos, de diretorios e de move objects.
Estão na seção de Screenshots


## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation -- not necessary for this PR

## Screenshots/Videos
![uploadobject](https://github.com/user-attachments/assets/1ec4e7c0-ce9a-4246-a8e7-bd83f7e859c1)
![list-with-prefix](https://github.com/user-attachments/assets/63bc48c2-13d3-4205-a96a-ddfdf3c844ef)
![list-diff](https://github.com/user-attachments/assets/62575354-d88e-491e-8921-4913d3fcee93)