### PR TITLE
fix: add required flag to batch_size param

### DIFF
--- a/mgc/cli/docs/object-storage/objects/delete-all.md
+++ b/mgc/cli/docs/object-storage/objects/delete-all.md
@@ -9,7 +9,7 @@ mgc object-storage objects delete-all [bucket] [flags]
 
 ## Flags:
 ```
-    --batch-size integer     Limit of items per batch to delete (range: 1 - 1000)
+    --batch-size integer     Limit of items per batch to delete (range: 1 - 1000) (required) (default 1000)
     --bucket string          Name of the bucket to delete objects from (required)
     --filter array(object)   File name pattern to include or exclude
                              Use --filter=help for more details

--- a/mgc/sdk/static/object_storage/common/delete.go
+++ b/mgc/sdk/static/object_storage/common/delete.go
@@ -43,7 +43,7 @@ type DeleteObjectsParams struct {
 
 type DeleteAllObjectsInBucketParams struct {
 	BucketName BucketName       `json:"bucket" jsonschema:"description=Name of the bucket to delete objects from" mgc:"positional"`
-	BatchSize  int              `json:"batch_size,omitempty" jsonschema:"description=Limit of items per batch to delete,default=1000,minimum=1,maximum=1000" example:"1000"`
+	BatchSize  int              `json:"batch_size,omitempty" jsonschema:"description=Limit of items per batch to delete,default=1000,minimum=1,maximum=1000,required" example:"1000"`
 	Filters    `json:",squash"` // nolint
 }
 


### PR DESCRIPTION
## What does this PR do?

Apply batch_size default when flag not provided

## How Has This Been Tested?
Manually with mgc cli and delve debugger
And s3-specs

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.

Running mgc os objects delete-all {bucket_name}

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works