### PR TITLE
fix: change when print outdated version

### DIFF
--- a/mgc/cli/cmd/handle_executor.go
+++ b/mgc/cli/cmd/handle_executor.go
@@ -157,6 +157,15 @@ func handleExecutor(
 		return nil, err
 	}
 
+	if !getRawOutputFlag(cmd) {
+		core.NewVersionChecker(
+			sdk.HttpClient().Get,
+			sdk.Config().Get,
+			sdk.Config().Set,
+		).
+			CheckVersion(sdk.GetVersion(), argParser.MainArgs()...)
+	}
+
 	result, err := handleExecutorPre(ctx, sdk, cmd, exec, parameters, configs)
 	err = handleExecutorResult(ctx, sdk, cmd, result, err)
 	if err != nil {

--- a/mgc/cli/cmd/load_cmd_tree.go
+++ b/mgc/cli/cmd/load_cmd_tree.go
@@ -124,16 +124,6 @@ var keepLoadingCommands = []string{
 
 func loadSdkCommandTree(sdk *mgcSdk.Sdk, cmd *cobra.Command, args []string) error {
 	root := sdk.Group()
-
-	if !getRawOutputFlag(cmd) {
-		core.NewVersionChecker(
-			sdk.HttpClient().Get,
-			sdk.Config().Get,
-			sdk.Config().Set,
-		).
-			CheckVersion(sdk.GetVersion(), args...)
-	}
-
 	if len(args) > 0 && slices.Contains(builtInCommands, args[0]) {
 		return loadAllChildren(sdk, cmd, root)
 	}


### PR DESCRIPTION
## What does this PR do?
<!-- Provide a clear and concise description of the changes -->
<!--Example: This PR adds a new endpoint to the API that allows users to retrieve their order history. It includes the necessary changes to the controller, service, and repository layers, as well as updates to the API documentation. -->

## How Has This Been Tested?
<!-- Please describe the tests you ran to verify your changes and how you tested them. Include any relevant details and evidence. -->
- **Unit Tests**: Describe the unit tests you have written and their outcomes.
  <!-- Example: Added unit tests for the new order history endpoint. All tests passed successfully. -->

- **Integration Tests**: Detail the integration tests performed and their results.
  <!-- Example: Performed integration tests with the payment service to ensure end-to-end functionality. All tests passed. -->

- **Manual Testing**: Explain the manual testing process, including steps taken and evidence such as screenshots or logs.
  <!-- Example: Manually tested the new endpoint using Postman. Verified that the correct order history is returned for different users. Attached screenshots of the Postman results. -->

## Checklist
- [ ] I have run Pre commit `pre-commit run --all-files`
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->

Antes:
<img width="995" height="522" alt="image" src="https://github.com/user-attachments/assets/5b427891-4f88-4e26-a3bc-e36292db4779" />

Depois:
<img width="1038" height="208" alt="image" src="https://github.com/user-attachments/assets/f068725c-1b2f-4d5e-a12e-c019daa05f43" />


Acontecia que a verificação de versão desatualizada acontecia antes que a CLI fizesse o parse completo das flags passadas na linha de comando, com isso, o print da mensagem dependia apenas do intervalo de tempo (via `~/.config/mgc/{workspace}/cli.yaml` ) 