### PR TITLE
feat: adds nix flake distribution

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "Magalu Nix distribution channel";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import nixpkgs { inherit system; };
+      });
+      mkDeps = pkgs: pkgs.stdenv.mkDerivation {
+        name = "cli-deps";
+        src = ./.;
+
+        nativeBuildInputs = [ pkgs.buildPackages.go ];
+
+        configurePhase = ''
+          export GOMODCACHE=$out
+          export GOPATH=$(mktemp -d)
+        '';
+
+        buildPhase = ''
+          export GOPROXY=https://proxy.golang.org,direct
+          go mod download
+        '';
+
+        dontInstall = true;
+
+        outputHashMode = "recursive";
+        outputHashAlgo = "sha256";
+        outputHash = "CGAdRjfU0BNk7kLxv8Uwr+lVw0nhffasYzznCy7Q/E4=";
+      };
+    in
+    {
+      packages = forAllSystems ({ pkgs }:
+        let
+          version = "0.53.0";
+          deps = mkDeps pkgs;
+
+          cli = pkgs.buildGoModule {
+            pname = "mgc";
+            inherit version;
+
+            src = pkgs.lib.cleanSource ./.;
+
+            modRoot = "./mgc/cli";
+
+            proxyVendor = true;
+            vendorHash = null;
+
+            preBuild = ''
+              export GOMODCACHE=${deps}
+            '';
+
+            tags = [ "embed" ];
+            ldflags = [ "-s" "-w" "-X" "main.RawVersion=v${version}" ];
+            subPackages = [ "." ];
+
+            postInstall = ''
+              mv $out/bin/cli $out/bin/mgc
+            '';
+          };
+
+          # Create aliases for the same package
+          packages = {
+            cli = cli;
+            deps = deps;
+            default = cli;
+          };
+        in
+        packages
+      );
+
+      apps = forAllSystems ({ pkgs }: {
+        cli = {
+          type = "app";
+          program = "${self.packages.${pkgs.system}.mgc}/bin/mgc";
+        };
+        default = self.apps.${pkgs.system}.cli;
+      });
+    };
+}


### PR DESCRIPTION
## What does this PR do?
This PR introduces a nix flake distribution to make the project more compatible with Nix-based environments.

## How Has This Been Tested?
- **Manual Testing**: Verified manually that the nix flake distribution builds correctly and can be installed using the standard nix package manager.

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
In this video I demonstrated how to start a new shell with the `mgc` CLI present, pointing to my github fork. After it is merged into main, it could be installed using `nix shell github:MagaluCloud/magalu`

https://github.com/user-attachments/assets/cfcb20d3-0f25-4e83-8662-888bf2da8ea3