### PR TITLE
Feat/blk confirmable condition

### DIFF
--- a/mgc/cli/cmd/handle_executor.go
+++ b/mgc/cli/cmd/handle_executor.go
@@ -88,13 +88,15 @@ func handleExecutorPre(
 
 	if cExec, ok := core.ExecutorAs[core.ConfirmableExecutor](exec); ok && !getBypassConfirmationFlag(cmd) {
 		msg := cExec.ConfirmPrompt(parameters, configs)
-		run, err := ui.Confirm(msg)
-		if err != nil {
-			return nil, err
-		}
+		if msg != "" {
+			run, err := ui.Confirm(msg)
+			if err != nil {
+				return nil, err
+			}
 
-		if !run {
-			return nil, core.UserDeniedConfirmationError{Prompt: msg}
+			if !run {
+				return nil, core.UserDeniedConfirmationError{Prompt: msg}
+			}
 		}
 	}
 	if pExec, ok := core.ExecutorAs[core.PromptInputExecutor](exec); ok && !getBypassConfirmationFlag(cmd) {

--- a/mgc/sdk/openapi/README.md
+++ b/mgc/sdk/openapi/README.md
@@ -129,6 +129,11 @@ Add this extension to an operation to require user confirmation before execution
 this extension by default). This extension is an object with a single string property called `message` used to define the
 confirmation message to be shown to the user.
 
+The `message` field is a Go template and has access to `{{.parameters}}` and `{{.configs}}`. If the rendered message is
+empty (e.g. when a conditional template evaluates to an empty string), the confirmation prompt is silently skipped — no
+question is shown to the user and execution proceeds normally. This allows conditional confirmations that only trigger
+when specific parameter values are present.
+
 
 ```yaml
 paths:
@@ -136,6 +141,16 @@ paths:
         patch:
             x-mgc-confirmable:
                 message: "This action requires confirmation. Are you sure you wish to continue?"
+```
+
+Conditional confirmation example — prompt is only shown when a specific parameter condition is met:
+
+```yaml
+paths:
+   /v0/some/path:
+        post:
+            x-mgc-confirmable:
+                message: "{{if not .parameters.encrypted}}WARNING: You are performing this action without encryption.\nAre you sure you want to proceed?{{end}}"
 ```
 
 ### `x-mgc-promptInput`

--- a/mgc/sdk/openapi/openapis/block-storage.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/block-storage.openapi.yaml
@@ -1326,6 +1326,11 @@ paths:
                     description: Unprocessable Entity
             x-viveiro: true
             x-permission-name: bs_volume_create
+            x-mgc-confirmable:
+                message: "{{if not .parameters.encrypted}}WARNING: You are creating\
+                    \ a volume WITHOUT encryption. \nThe recommended policy is to\
+                    \ keep encryption enabled. \nAre you sure you want to proceed\
+                    \ without encryption?{{end}}"
             security:
             -   OAuth2:
                 - block-storage.write

--- a/specs/conv.block-storage.jaxyendy.openapi.json
+++ b/specs/conv.block-storage.jaxyendy.openapi.json
@@ -1648,7 +1648,10 @@
           }
         },
         "x-viveiro": true,
-        "x-permission-name": "bs_volume_create"
+        "x-permission-name": "bs_volume_create",
+        "x-mgc-confirmable": {
+          "message": "{{if not .parameters.encrypted}}WARNING: You are creating a volume WITHOUT encryption. \nThe recommended policy is to keep encryption enabled. \nAre you sure you want to proceed without encryption?{{end}}"
+        }
       }
     },
     "/v1/volumes/{id}": {


### PR DESCRIPTION
## What does this PR do?
1. Confirmação condicional no handle_executor.go
- Foi adicionada uma verificação no ConfirmableExecutor: se msg == "", o prompt é silenciosamente ignorado e a execução prossegue normalmente. Isso permite que templates condicionais controlem se a confirmação deve ou não aparecer.

2. Uso prático no block-storage.openapi.yaml
- Foi adicionada a extensão x-mgc-confirmable na operação de criação de volumes do Block Storage. A mensagem usa um template condicional:

- "Se o volume for criado sem criptografia, avisa o usuário e pede confirmação."

3. Documentação atualizada no README.md
- A descrição da extensão x-mgc-confirmable foi atualizada para refletir o comportamento novo.

## How Has This Been Tested?
- Executando localmente
<img width="577" height="90" alt="image" src="https://github.com/user-attachments/assets/0fefa042-5f2f-47d5-b702-93c0e8496086" />
<img width="651" height="38" alt="image" src="https://github.com/user-attachments/assets/81fd4cb5-ebe5-4843-8302-ce878b891692" />

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->