### PR TITLE
Fix: cli-watch update k8s cluster

### DIFF
--- a/mgc/cli/docs/kubernetes/cluster/update.md
+++ b/mgc/cli/docs/kubernetes/cluster/update.md
@@ -19,6 +19,7 @@ mgc kubernetes cluster update --description="This is an example cluster."
 ```
     --allowed-cidrs array(string)   
     --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
+    --cli.watch                     Wait until the operation is completed by calling the 'get' link and waiting until termination. Akin to '! get -w'
     --cluster-id uuid               Cluster's UUID (required)
     --description string            A brief description of the Kubernetes cluster.
 -h, --help                          help for update

--- a/mgc/sdk/openapi/openapis/kubernetes.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/kubernetes.openapi.yaml
@@ -791,6 +791,10 @@ paths:
                                 $ref: '#/components/schemas/PatchClusterResponse'
                     links:
                         get:
+                            x-mgc-wait-termination:
+                                interval: 5s
+                                maxRetries: 60
+                                jsonPathQuery: $.result.status.state == "Running"
                             operationId: getClusterById
                             description: List a cluster by uuid
                             parameters:

--- a/specs/kubernetes.jaxyendy.openapi.json
+++ b/specs/kubernetes.jaxyendy.openapi.json
@@ -721,6 +721,15 @@
                   "$ref": "#/components/schemas/PatchClusterResponse"
                 }
               }
+            },
+            "links": {
+              "get": {
+                "x-mgc-wait-termination": {
+                  "interval": "5s",
+                  "maxRetries": 60,
+                  "jsonPathQuery": "$.result.status.state == \"Running\""
+                }
+              }
             }
           },
           "400": {


### PR DESCRIPTION
## What does this PR do?
Volta com a flag --cli.watch no update de cluster k8s que foi removida por engano

## How Has This Been Tested?
Request: mgc k8s cluster update "<UUID>" --allowed-cidrs "0.0.0.0/0" --cli.watch

Response:
{                                                                                                                                                               
 "allowed_cidrs": [
  "0.0.0.0/0"
 ]
}


## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation