### PR TITLE
fix: descomprime respostas HTTP com Content-Encoding gzip/deflate/br

### DIFF
--- a/mgc/core/go.mod
+++ b/mgc/core/go.mod
@@ -24,6 +24,7 @@ require (
 )
 
 require (
+	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect

--- a/mgc/core/go.sum
+++ b/mgc/core/go.sum
@@ -6,6 +6,8 @@ github.com/PaesslerAG/gval v1.2.4/go.mod h1:XRFLwvmkTEdYziLdaCeCa5ImcGVrfQbeNUbV
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
+github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
+github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=

--- a/mgc/core/http/http.go
+++ b/mgc/core/http/http.go
@@ -80,10 +80,10 @@ func DecompressResponse(resp *http.Response) error {
 		}
 		wrapped = &decompressedBody{Reader: gzr, closers: []io.Closer{gzr, original}}
 	case "deflate":
-		// HTTP spec diz que "deflate" é zlib (RFC 1950), mas o IIS da Microsoft
-		// historicamente envia raw DEFLATE (RFC 1951) e outros servidores copiaram
-		// esse comportamento. Inspecionamos o header sem consumir bytes para escolher
-		// o reader correto.
+		// The HTTP spec defines "deflate" as zlib (RFC 1950), but Microsoft's IIS
+		// historically sends raw DEFLATE (RFC 1951), a behavior subsequently
+		// adopted by other servers. We inspect the header without consuming bytes
+		// to select the appropriate reader.
 		buffered := bufio.NewReader(original)
 		var dr io.ReadCloser
 		if hasZlibHeader(buffered) {
@@ -111,10 +111,10 @@ func DecompressResponse(resp *http.Response) error {
 	return nil
 }
 
-// hasZlibHeader inspeciona (sem consumir) os 2 primeiros bytes para decidir se
-// o stream é zlib (RFC 1950) ou raw DEFLATE (RFC 1951). Um header zlib válido
-// tem o método de compressão deflate (low nibble do CMF == 8) e (CMF*256+FLG)
-// múltiplo de 31.
+// hasZlibHeader inspects the first 2 bytes to determine whether the
+// stream is zlib (RFC 1950) or raw DEFLATE (RFC 1951). A valid zlib
+// header uses the deflate compression method (low nibble of CMF == 8)
+// and (CMF * 256 + FLG) must be a multiple of 31.
 func hasZlibHeader(br *bufio.Reader) bool {
 	header, err := br.Peek(2)
 	if err != nil || len(header) < 2 {

--- a/mgc/core/http/http.go
+++ b/mgc/core/http/http.go
@@ -1,7 +1,9 @@
 package http
 
 import (
+	"bufio"
 	"bytes"
+	"compress/flate"
 	"compress/gzip"
 	"compress/zlib"
 	"context"
@@ -78,11 +80,22 @@ func DecompressResponse(resp *http.Response) error {
 		}
 		wrapped = &decompressedBody{Reader: gzr, closers: []io.Closer{gzr, original}}
 	case "deflate":
-		zr, err := zlib.NewReader(original)
-		if err != nil {
-			return fmt.Errorf("error creating deflate reader: %w", err)
+		// HTTP spec diz que "deflate" é zlib (RFC 1950), mas o IIS da Microsoft
+		// historicamente envia raw DEFLATE (RFC 1951) e outros servidores copiaram
+		// esse comportamento. Inspecionamos o header sem consumir bytes para escolher
+		// o reader correto.
+		buffered := bufio.NewReader(original)
+		var dr io.ReadCloser
+		if hasZlibHeader(buffered) {
+			zr, err := zlib.NewReader(buffered)
+			if err != nil {
+				return fmt.Errorf("error creating deflate reader: %w", err)
+			}
+			dr = zr
+		} else {
+			dr = flate.NewReader(buffered)
 		}
-		wrapped = &decompressedBody{Reader: zr, closers: []io.Closer{zr, original}}
+		wrapped = &decompressedBody{Reader: dr, closers: []io.Closer{dr, original}}
 	case "br":
 		br := brotli.NewReader(original)
 		wrapped = &decompressedBody{Reader: br, closers: []io.Closer{original}}
@@ -96,6 +109,22 @@ func DecompressResponse(resp *http.Response) error {
 	resp.ContentLength = -1
 	resp.Uncompressed = true
 	return nil
+}
+
+// hasZlibHeader inspeciona (sem consumir) os 2 primeiros bytes para decidir se
+// o stream é zlib (RFC 1950) ou raw DEFLATE (RFC 1951). Um header zlib válido
+// tem o método de compressão deflate (low nibble do CMF == 8) e (CMF*256+FLG)
+// múltiplo de 31.
+func hasZlibHeader(br *bufio.Reader) bool {
+	header, err := br.Peek(2)
+	if err != nil || len(header) < 2 {
+		return false
+	}
+	cmf, flg := header[0], header[1]
+	if cmf&0x0F != 8 {
+		return false
+	}
+	return (uint16(cmf)<<8|uint16(flg))%31 == 0
 }
 
 type decompressedBody struct {

--- a/mgc/core/http/http.go
+++ b/mgc/core/http/http.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"bytes"
+	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,6 +19,7 @@ import (
 	"github.com/MagaluCloud/magalu/mgc/core"
 	"github.com/MagaluCloud/magalu/mgc/core/utils"
 	"github.com/MagaluCloud/magalu/mgc/core/xml"
+	"github.com/andybalholm/brotli"
 )
 
 // contextKey is an unexported type for keys defined in this package.
@@ -49,6 +52,65 @@ func ClientFromContext(context context.Context) *Client {
 		return nil
 	}
 	return client
+}
+
+// DecompressResponse wraps resp.Body with the appropriate decoder based on the
+// Content-Encoding header, then clears the encoding metadata so downstream
+// consumers see a transparent stream. Net/http only auto-decompresses gzip
+// when the caller did not set Accept-Encoding itself; we advertise it
+// explicitly, so the decode is our responsibility.
+func DecompressResponse(resp *http.Response) error {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+	encoding := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Encoding")))
+	if encoding == "" || encoding == "identity" {
+		return nil
+	}
+
+	original := resp.Body
+	var wrapped io.ReadCloser
+	switch encoding {
+	case "gzip", "x-gzip":
+		gzr, err := gzip.NewReader(original)
+		if err != nil {
+			return fmt.Errorf("error creating gzip reader: %w", err)
+		}
+		wrapped = &decompressedBody{Reader: gzr, closers: []io.Closer{gzr, original}}
+	case "deflate":
+		zr, err := zlib.NewReader(original)
+		if err != nil {
+			return fmt.Errorf("error creating deflate reader: %w", err)
+		}
+		wrapped = &decompressedBody{Reader: zr, closers: []io.Closer{zr, original}}
+	case "br":
+		br := brotli.NewReader(original)
+		wrapped = &decompressedBody{Reader: br, closers: []io.Closer{original}}
+	default:
+		return nil
+	}
+
+	resp.Body = wrapped
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	resp.Uncompressed = true
+	return nil
+}
+
+type decompressedBody struct {
+	io.Reader
+	closers []io.Closer
+}
+
+func (d *decompressedBody) Close() error {
+	var firstErr error
+	for _, c := range d.closers {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func BodyReaderSafe(resp *http.Response) (io.ReadCloser, error) {

--- a/mgc/sdk/openapi/operation.go
+++ b/mgc/sdk/openapi/operation.go
@@ -796,6 +796,11 @@ func (o *operation) Execute(
 		return nil, fmt.Errorf("HTTP request error: %w", err)
 	}
 
+	if err := mgcHttpPkg.DecompressResponse(resp); err != nil {
+		logger.Warnw("failed to decompress HTTP response", "error", err)
+		return nil, err
+	}
+
 	logger = logger.With("response", (*mgcHttpPkg.LogResponse)(resp))
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		logger.Debugw("failed to execute HTTP request", "error", err)


### PR DESCRIPTION
## What does this PR do?

- Nas requisições http, o cliente envia `Accept-Encoding: gzip, deflate, br` explicitamente. Porém, não havia descompressão manual em nenhum ponto, então qualquer endpoint que honre o `Accept-Encoding` e retorne `Content-Encoding: gzip` chega no parser de JSON como bytes binários crus, falhando o unmarshal.

- Foi tratado  o response body de acordo com o Content-Encoding **em todos os comandos da CLI**, usando a lib `brotli`.


## How Has This Been Tested?
Reverse proxy local que injeta `Content-Encoding: gzip` em qualquer resposta http.

<img width="1559" height="797" alt="image" src="https://github.com/user-attachments/assets/769ded95-e23b-4d27-bfbb-c47cd715058e" />


## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
