### PR TITLE
fix: object storage creation and object-lock

### DIFF
--- a/mgc/cli/docs/object-storage/buckets/create.md
+++ b/mgc/cli/docs/object-storage/buckets/create.md
@@ -13,7 +13,7 @@ mgc object-storage buckets create [bucket] [flags]
 ## Flags:
 ```
     --bucket string                 Name of the bucket to be created (required)
-    --bucket-is-prefix              Use bucket name as prefix value to generate a unique bucket name (required)
+    --bucket-is-prefix              Use bucket name as prefix value to generate a unique bucket name (default false)
     --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
     --enable-versioning             Enable versioning for this bucket (default true)
     --grant-write array(object)     Allows grantees to create objects in the bucket

--- a/mgc/cli/docs/object-storage/buckets/create.md
+++ b/mgc/cli/docs/object-storage/buckets/create.md
@@ -15,7 +15,7 @@ mgc object-storage buckets create [bucket] [flags]
     --bucket string                 Name of the bucket to be created (required)
     --bucket-is-prefix              Use bucket name as prefix value to generate a unique bucket name (required)
     --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
-    --enable-versioning             Enable versioning for this bucket (required) (default true)
+    --enable-versioning             Enable versioning for this bucket (default true)
     --grant-write array(object)     Allows grantees to create objects in the bucket
                                     Use --grant-write=help for more details
 -h, --help                          help for create

--- a/mgc/sdk/static/object_storage/buckets/create.go
+++ b/mgc/sdk/static/object_storage/buckets/create.go
@@ -20,7 +20,7 @@ var createLogger = utils.NewLazyLoader(func() *zap.SugaredLogger {
 type createParams struct {
 	BucketName            common.BucketName `json:"bucket" jsonschema:"description=Name of the bucket to be created" mgc:"positional"`
 	IsPrefix              bool              `json:"bucket_is_prefix" jsonschema:"description=Use bucket name as prefix value to generate a unique bucket name,default=false"`
-	EnableVersioning      bool              `json:"enable_versioning,omitempty" jsonschema:"description=Enable versioning for this bucket,default=true,required"`
+	EnableVersioning      *bool             `json:"enable_versioning,omitempty" jsonschema:"description=Enable versioning for this bucket (default true)"`
 	common.ACLPermissions `json:",squash"`  // nolint
 }
 
@@ -119,7 +119,18 @@ func create(ctx context.Context, params createParams, cfg common.Config) (*creat
 
 	logger.Info("bucket created successfully")
 
-	if !params.EnableVersioning {
+	enableVersioning := true
+	if params.EnableVersioning == nil {
+		params.EnableVersioning = &enableVersioning
+	}
+
+	if *params.EnableVersioning {
+		logger.Info("enabling bucket versioning, as 'enable_versioning' was passed as true")
+		_, err := versioning.EnableBucketVersioning(ctx, versioning.EnableBucketVersioningParams{Bucket: params.BucketName}, cfg)
+		if err != nil {
+			return nil, err
+		}
+	} else {
 		logger.Info("suspending bucket versioning, as 'enable_versioning' was passed as false")
 		_, err := versioning.SuspendBucketVersioning(ctx, versioning.SuspendBucketVersioningParams{Bucket: params.BucketName}, cfg)
 		if err != nil {

--- a/mgc/sdk/static/object_storage/buckets/create.go
+++ b/mgc/sdk/static/object_storage/buckets/create.go
@@ -19,7 +19,7 @@ var createLogger = utils.NewLazyLoader(func() *zap.SugaredLogger {
 
 type createParams struct {
 	BucketName            common.BucketName `json:"bucket" jsonschema:"description=Name of the bucket to be created" mgc:"positional"`
-	IsPrefix              bool              `json:"bucket_is_prefix" jsonschema:"description=Use bucket name as prefix value to generate a unique bucket name,default=false"`
+	IsPrefix              bool              `json:"bucket_is_prefix,omitempty" jsonschema:"description=Use bucket name as prefix value to generate a unique bucket name (default false)"`
 	EnableVersioning      *bool             `json:"enable_versioning,omitempty" jsonschema:"description=Enable versioning for this bucket (default true)"`
 	common.ACLPermissions `json:",squash"`  // nolint
 }

--- a/mgc/sdk/static/object_storage/buckets/object-lock/get.go
+++ b/mgc/sdk/static/object_storage/buckets/object-lock/get.go
@@ -11,7 +11,7 @@ import (
 )
 
 type GetBucketObjectLockResponse struct {
-	ObjectLockEnabled string
+	ObjectLockEnabled string `xml:"ObjectLockEnabled"`
 	Rule              common.ObjectLockRule
 }
 
@@ -50,9 +50,10 @@ func GetObjectLocking(ctx context.Context, params GetBucketObjectLockParams, cfg
 	// Como precisamos tratar esse caso de maneira específica, usamos um erro com tipo específico.
 	if res.StatusCode == 400 {
 		err = ErrBucketMissingObjectLockConfiguration
+		return
 	}
 
-	return
+	return common.UnwrapResponse[GetBucketObjectLockResponse](res, req)
 }
 
 func newGetObjectLockingRequest(ctx context.Context, cfg common.Config, bucketName common.BucketName) (*http.Request, error) {

--- a/mgc/sdk/static/object_storage/buckets/versioning/enable.go
+++ b/mgc/sdk/static/object_storage/buckets/versioning/enable.go
@@ -9,7 +9,7 @@ import (
 	"github.com/MagaluCloud/magalu/mgc/sdk/static/object_storage/common"
 )
 
-type enableBucketVersioningParams struct {
+type EnableBucketVersioningParams struct {
 	Bucket common.BucketName `json:"bucket" jsonschema:"description=Bucket name to enable versioning" mgc:"positional"`
 }
 
@@ -19,7 +19,7 @@ var getEnable = utils.NewLazyLoader(func() core.Executor {
 			Name:        "enable",
 			Description: "Enable versioning for a Bucket",
 		},
-		enableBucketVersioning,
+		EnableBucketVersioning,
 	)
 
 	return core.NewExecuteResultOutputOptions(exec, func(exec core.Executor, result core.Result) string {
@@ -27,7 +27,7 @@ var getEnable = utils.NewLazyLoader(func() core.Executor {
 	})
 })
 
-func enableBucketVersioning(ctx context.Context, params enableBucketVersioningParams, cfg common.Config) (core.Value, error) {
+func EnableBucketVersioning(ctx context.Context, params EnableBucketVersioningParams, cfg common.Config) (core.Value, error) {
 	req, err := newEnableBucketVersioningRequest(ctx, params.Bucket, cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What does this PR do?
- Corrigido a criação do bucket quando o usuário passa o `--versioning-enable=true` pois não estava sendo habilitado
- Removido o texto `required` do `--versioning-enable` e `--bucket-is-prefix` pois não estão funcionando como obrigatórios
- Corrigido o comando `mgc os buckets object-lock get` pois não estava sendo mostrado as configurações corretamente

## How Has This Been Tested?
Foi realizado o build e testado os comandos alterados

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->