### PR TITLE
 Feat: Adicionando membros aos grupos IAM pelo email

### DIFF
--- a/mgc/cli/docs/iam/Groups/members/create.md
+++ b/mgc/cli/docs/iam/Groups/members/create.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 ---
 # Create
 
-Add a member to a group.
+Add a member to a group by email.
 
 ## Usage:
 ```
@@ -15,7 +15,7 @@ mgc iam groups members create [group-id] [flags]
     --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
     --group-id string               Group Id (required)
 -h, --help                          help for create
-    --member-id string              Member Id (required)
+    --member-email email            Member Email (required)
     --profile string                Profile (required)
 ```
 

--- a/mgc/sdk/openapi/openapis/iam.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/iam.openapi.yaml
@@ -1843,8 +1843,31 @@ paths:
             - Groups
             - Groups
             summary: Add Member To Group
-            description: Add a member to a group.
+            description: 'Add a member to a group by email.
+
+
+                The API accepts the user''s email address and automatically resolves
+
+                it to the corresponding UUID before adding the member to the group.
+
+
+                - **member_email**: Valid email address of the user to add
+
+                - **profile**: Member profile (e.g., "member", "admin")
+
+
+                Raises:
+
+                - 422: Invalid email format
+
+                - 404: User email not found in ID Magalu
+
+                - 400: Service accounts or groups cannot be added to groups'
             operationId: add_member_to_group_api_v1_groups__group_id__members_post
+            security:
+            -   OAuth2:
+                - iam:read
+                - iam:write
             parameters:
             -   name: group_id
                 in: path
@@ -1853,11 +1876,11 @@ paths:
                     type: string
                     title: Group Id
             requestBody:
+                required: true
                 content:
                     application/json:
                         schema:
                             $ref: '#/components/schemas/MemberGroupCreate'
-                required: true
             responses:
                 '201':
                     description: Successful Response
@@ -1876,13 +1899,13 @@ paths:
                             description: Update Group Member
                             parameters:
                                 group_id: $request.path.group_id
-                                member_id: $request.body#/member_id
+                                member_id: $response.body#/member_id
                         delete:
                             operationId: remove_member_from_group_api_v1_groups__group_id__members__member_id__delete
                             description: Remove Member From Group
                             parameters:
                                 group_id: $request.path.group_id
-                                member_id: $request.body#/member_id
+                                member_id: $response.body#/member_id
                 '422':
                     description: Validation Error
                     content:
@@ -1899,10 +1922,6 @@ paths:
                                 product: turiaiam
                                 message: User action not authorized for permission
                                     turia_iam_editor
-            security:
-            -   OAuth2:
-                - iam:read
-                - iam:write
     /api/v1/groups/{group_id}/members/{member_id}:
         delete:
             tags:
@@ -2564,18 +2583,19 @@ components:
                     type: string
             title: MemberCreated
         MemberGroupCreate:
-            type: object
             properties:
-                member_id:
+                member_email:
                     type: string
-                    title: Member Id
+                    format: email
+                    title: Member Email
                 profile:
                     type: string
                     title: Profile
-            title: MemberGroupCreate
+            type: object
             required:
-            - member_id
+            - member_email
             - profile
+            title: MemberGroupCreate
         MemberGroupResponse:
             type: object
             properties:

--- a/specs/iam.jaxyendy.openapi.json
+++ b/specs/iam.jaxyendy.openapi.json
@@ -2641,14 +2641,22 @@
           }
         ]
       },
-      "post": {
+       "post": {
         "tags": [
           "Groups",
           "Groups"
         ],
         "summary": "Add Member To Group",
-        "description": "Add a member to a group.",
+        "description": "Add a member to a group by email.\n\nThe API accepts the user's email address and automatically resolves\nit to the corresponding UUID before adding the member to the group.\n\n- **member_email**: Valid email address of the user to add\n- **profile**: Member profile (e.g., \"member\", \"admin\")\n\nRaises:\n- 422: Invalid email format\n- 404: User email not found in ID Magalu\n- 400: Service accounts or groups cannot be added to groups",
         "operationId": "add_member_to_group_api_v1_groups__group_id__members_post",
+        "security": [
+          {
+            "OAuth2": [
+              "iam:read",
+              "iam:write"
+            ]
+          }
+        ],
         "parameters": [
           {
             "name": "group_id",
@@ -2661,14 +2669,14 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/MemberGroupCreate"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "201": {
@@ -2704,15 +2712,7 @@
               }
             }
           }
-        },
-        "security": [
-          {
-            "OAuth2": [
-              "iam:read",
-              "iam:write"
-            ]
-          }
-        ]
+        }
       }
     },
     "/api/v1/groups/{group_id}/members/{member_id}": {
@@ -3827,22 +3827,23 @@
         "title": "MemberCreated"
       },
       "MemberGroupCreate": {
-        "type": "object",
         "properties": {
-          "member_id": {
+          "member_email": {
             "type": "string",
-            "title": "Member Id"
+            "format": "email",
+            "title": "Member Email"
           },
           "profile": {
             "type": "string",
             "title": "Profile"
           }
         },
-        "title": "MemberGroupCreate",
+        "type": "object",
         "required": [
-          "member_id",
+          "member_email",
           "profile"
-        ]
+        ],
+        "title": "MemberGroupCreate"
       },
       "MemberGroupResponse": {
         "type": "object",


### PR DESCRIPTION
## What does this PR do?
Altera o comando `mgc iam groups members create` para adicionar membros por e-mail ao invés do UUID

## How Has This Been Tested?
Executando o comando localmente `mgc iam groups members create --group-id <GROU_UUID> --member-email "<MEMBER_EMAIL>" --profile member`

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
