### PR TITLE
fix: ajuste descricao das flags do comando mgc container-registry mem…

### DIFF
--- a/mgc/cli/docs/container-registry/members/update.md
+++ b/mgc/cli/docs/container-registry/members/update.md
@@ -15,8 +15,8 @@ mgc container-registry members update [registry-id] [member-id] [flags]
     --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
     --cli.watch                     Wait until the operation is completed by calling the 'get' link and waiting until termination. Akin to '! get -w'
 -h, --help                          help for update
-    --member-id uuid                 (required)
-    --registry-id uuid               (required)
+    --member-id uuid                Registry member relationship UUID. (required)
+    --registry-id uuid              Container Registry's UUID. (required)
     --role enum                     The new role to assign to the member. (one of "developer" or "guest") (required)
 ```
 

--- a/mgc/sdk/openapi/openapis/container-registry.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/container-registry.openapi.yaml
@@ -994,12 +994,14 @@ paths:
                 schema:
                     type: string
                     format: uuid
+                description: Container Registry's UUID.
             -   name: member_id
                 in: path
                 required: true
                 schema:
                     type: string
                     format: uuid
+                description: Registry member relationship UUID.
             requestBody:
                 required: true
                 content:

--- a/specs/container-registry.openapi.yaml
+++ b/specs/container-registry.openapi.yaml
@@ -856,12 +856,14 @@ paths:
           schema:
             type: string
             format: uuid
+          description: Container Registry's UUID.
         - name: member_id
           in: path
           required: true
           schema:
             type: string
             format: uuid
+          description: Registry member relationship UUID.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
…bers update

## What does this PR do?
Ajusta a descrição das flags `--registry-id`  e `--repository-id` do comando `mgc container-registry members update`

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
