### PR TITLE
feat: adicionando update de versão de cluster e nodepool kubernetes

### DIFF
--- a/mgc/cli/docs/kubernetes/cluster/update.md
+++ b/mgc/cli/docs/kubernetes/cluster/update.md
@@ -12,7 +12,7 @@ mgc kubernetes cluster update [cluster-id] [flags]
 
 ## Examples:
 ```
-mgc kubernetes cluster update --description="This is an example cluster."
+mgc kubernetes cluster update --description="This is an example cluster." --version="v1.31.0"
 ```
 
 ## Flags:
@@ -23,6 +23,11 @@ mgc kubernetes cluster update --description="This is an example cluster."
     --cluster-id uuid               Cluster's UUID (required)
     --description string            A brief description of the Kubernetes cluster.
 -h, --help                          help for update
+    --version string                The target Kubernetes version for the cluster upgrade.
+                                    
+                                    **Supported Upgrade Paths:**
+                                    * **Patch:** Same minor version (e.g., 'v1.30.1' → 'v1.30.2')
+                                    * **Minor:** Next consecutive minor version (e.g., 'v1.30.1' → 'v1.31.0')
 ```
 
 ## Global Flags:

--- a/mgc/cli/docs/kubernetes/nodepool/update.md
+++ b/mgc/cli/docs/kubernetes/nodepool/update.md
@@ -12,7 +12,7 @@ mgc kubernetes nodepool update [cluster-id] [node-pool-id] [flags]
 
 ## Examples:
 ```
-mgc kubernetes nodepool update --auto-scale.max-replicas=5 --auto-scale.min-replicas=2 --flavor="BV2-4-40"
+mgc kubernetes nodepool update --auto-scale.max-replicas=5 --auto-scale.min-replicas=2 --flavor="BV2-4-40" --version="v1.31.0"
 ```
 
 ## Flags:
@@ -36,6 +36,11 @@ mgc kubernetes nodepool update --auto-scale.max-replicas=5 --auto-scale.min-repl
 -h, --help                              help for update
     --node-pool-id uuid                 Nodepool's UUID. (required)
     --replicas integer                  Number of replicas of the nodes in the node pool.
+    --version string                    The target Kubernetes version for the cluster upgrade.
+                                        
+                                        **Supported Upgrade Paths:**
+                                        * **Patch:** Same minor version (e.g., 'v1.30.1' → 'v1.30.2')
+                                        * **Minor:** Next consecutive minor version (e.g., 'v1.30.1' → 'v1.31.0')
 ```
 
 ## Global Flags:

--- a/mgc/sdk/openapi/openapis/kubernetes.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/kubernetes.openapi.yaml
@@ -2565,6 +2565,8 @@ components:
                     $ref: '#/components/schemas/AutoScale'
                 flavor:
                     $ref: '#/components/schemas/NodePoolFlavor'
+                version:
+                    $ref: '#/components/schemas/KubernetesVersion'
         PatchClusterRequest:
             type: object
             description: Cluster fields to be patched
@@ -2575,6 +2577,8 @@ components:
                         type: string
                 description:
                     $ref: '#/components/schemas/Description'
+                version:
+                    $ref: '#/components/schemas/KubernetesVersion'
         PatchClusterResponse:
             type: object
             description: Object for cluster patch response
@@ -2585,6 +2589,8 @@ components:
                         type: string
                 description:
                     $ref: '#/components/schemas/Description'
+                version:
+                    $ref: '#/components/schemas/KubernetesVersion'
         KubeApiServer:
             type: object
             description: Information about the Kubernetes API Server of the cluster.
@@ -3524,6 +3530,23 @@ components:
             description: A brief description of the Kubernetes cluster.
             default: ''
             example: This is an example cluster.
+        KubernetesVersion:
+            type: string
+            description: 'The target Kubernetes version for the cluster upgrade.
+
+
+                **Supported Upgrade Paths:**
+
+                * **Patch:** Same minor version (e.g., `v1.30.1` → `v1.30.2`)
+
+                * **Minor:** Next consecutive minor version (e.g., `v1.30.1` → `v1.31.0`)
+
+                '
+            example: v1.31.0
+            x-go-type: semver.Version
+            x-go-type-import:
+                path: github.com/Masterminds/semver/v3
+                name: semver
     securitySchemes:
         BearerAuth:
             type: http

--- a/specs/kubernetes.jaxyendy.openapi.json
+++ b/specs/kubernetes.jaxyendy.openapi.json
@@ -2513,6 +2513,9 @@
           },
           "flavor": {
             "$ref": "#/components/schemas/NodePoolFlavor"
+          },
+          "version": {
+            "$ref": "#/components/schemas/KubernetesVersion"
           }
         }
       },
@@ -2528,6 +2531,9 @@
           },
           "description": {
             "$ref": "#/components/schemas/Description"
+          },
+          "version": {
+            "$ref": "#/components/schemas/KubernetesVersion"
           }
         }
       },
@@ -2543,6 +2549,9 @@
           },
           "description": {
             "$ref": "#/components/schemas/Description"
+          },
+          "version": {
+            "$ref": "#/components/schemas/KubernetesVersion"
           }
         }
       },
@@ -3536,6 +3545,16 @@
         "description": "A brief description of the Kubernetes cluster.",
         "default": "",
         "example": "This is an example cluster."
+      },
+      "KubernetesVersion": {
+        "type": "string",
+        "description": "The target Kubernetes version for the cluster upgrade.\n\n**Supported Upgrade Paths:**\n* **Patch:** Same minor version (e.g., `v1.30.1` → `v1.30.2`)\n* **Minor:** Next consecutive minor version (e.g., `v1.30.1` → `v1.31.0`)\n",
+        "example": "v1.31.0",
+        "x-go-type": "semver.Version",
+        "x-go-type-import": {
+          "path": "github.com/Masterminds/semver/v3",
+          "name": "semver"
+        }
       }
     },
     "securitySchemes": {


### PR DESCRIPTION
## What does this PR do?
Nova funcionalidade de atualizar a versão de kubernetes (nodepool e cluster) sem a necessidade de reprovisionar. 

## How Has This Been Tested?
comando executados localmente 

mgc kubernetes nodepool update --version="v1.35.2"
mgc kubernetes cluster update --version="v1.35.2"

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works