### PR TITLE
fix: param enableVersioning default: false on bucket creation

### DIFF
--- a/mgc/cli/docs/object-storage/buckets/create.md
+++ b/mgc/cli/docs/object-storage/buckets/create.md
@@ -15,7 +15,7 @@ mgc object-storage buckets create [bucket] [flags]
     --bucket string                 Name of the bucket to be created (required)
     --bucket-is-prefix              Use bucket name as prefix value to generate a unique bucket name (default false)
     --cli.list-links enum[=table]   List all available links for this command (one of "json", "table" or "yaml")
-    --enable-versioning             Enable versioning for this bucket (default true)
+    --enable-versioning             Enable versioning for this bucket (default false)
     --grant-write array(object)     Allows grantees to create objects in the bucket
                                     Use --grant-write=help for more details
 -h, --help                          help for create

--- a/mgc/sdk/static/object_storage/buckets/create.go
+++ b/mgc/sdk/static/object_storage/buckets/create.go
@@ -20,7 +20,7 @@ var createLogger = utils.NewLazyLoader(func() *zap.SugaredLogger {
 type createParams struct {
 	BucketName            common.BucketName `json:"bucket" jsonschema:"description=Name of the bucket to be created" mgc:"positional"`
 	IsPrefix              bool              `json:"bucket_is_prefix,omitempty" jsonschema:"description=Use bucket name as prefix value to generate a unique bucket name (default false)"`
-	EnableVersioning      *bool             `json:"enable_versioning,omitempty" jsonschema:"description=Enable versioning for this bucket (default true)"`
+	EnableVersioning      *bool             `json:"enable_versioning,omitempty" jsonschema:"description=Enable versioning for this bucket (default false)"`
 	common.ACLPermissions `json:",squash"`  // nolint
 }
 
@@ -119,7 +119,7 @@ func create(ctx context.Context, params createParams, cfg common.Config) (*creat
 
 	logger.Info("bucket created successfully")
 
-	enableVersioning := true
+	enableVersioning := false
 	if params.EnableVersioning == nil {
 		params.EnableVersioning = &enableVersioning
 	}


### PR DESCRIPTION
## What does this PR do?
altera o valor padrão da variável `enable_versioning` para `false` na criação de bucket. 

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<img width="448" height="107" alt="image" src="https://github.com/user-attachments/assets/0818f1a0-83e9-4521-a8fd-f8258a14ad06" />