### PR TITLE
feat: Adding support for creating instances with multiple VNICs

### DIFF
--- a/mgc/cli/docs/virtual-machine/images/custom/update.md
+++ b/mgc/cli/docs/virtual-machine/images/custom/update.md
@@ -16,13 +16,13 @@ mgc virtual-machine images custom update [id] [flags]
     --description string            Description
 -h, --help                          help for update
     --id uuid                       Id (required)
-    --requirements object           (properties: disk, ram and vcpu)
+    --requirements object           [Deprecated] Deprecated: this field is ignored. (properties: disk, ram and vcpu) 
                                     Use --requirements=help for more details
-    --requirements.disk integer     requirements's disk property: Disk
+    --requirements.disk integer     Deprecated: Disk
                                     This is the same as '--requirements=disk:integer'.
-    --requirements.ram integer      requirements's ram property: Ram
+    --requirements.ram integer      Deprecated: Ram
                                     This is the same as '--requirements=ram:integer'.
-    --requirements.vcpu integer     requirements's vcpu property: Vcpu
+    --requirements.vcpu integer     Deprecated: Vcpu
                                     This is the same as '--requirements=vcpu:integer'.
     --version string                Version
 ```

--- a/mgc/cli/docs/virtual-machine/instances/create.md
+++ b/mgc/cli/docs/virtual-machine/instances/create.md
@@ -12,7 +12,7 @@ mgc virtual-machine instances create [flags]
 
 ## Examples:
 ```
-mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --image.name="some_resource_name" --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name" --volumes='[{"id":"a46594d1-9dc3-4c36-8eb3-071259513854"}]'
+mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --image.name="some_resource_name" --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network-profile.interfaces='[{"associate_public_ip":true,"security_groups":[{"id":"f273fbde-2ddf-4dcd-8c41-342671ac0d17"},{"id":"02a2acf3-d6db-4424-ac97-0254cb9c329e"}],"subnets":[{"id":"f273fbde-2ddf-4dcd-8c41-342671ac0d17"}],"tag":"primary","vpc":{"id":"2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"}}]' --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.interface.subnets='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name" --volumes='[{"id":"a46594d1-9dc3-4c36-8eb3-071259513854"}]'
 ```
 
 ## Flags:
@@ -36,9 +36,14 @@ mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d9
     --name string                               Name (between 1 and 255 characters) (required)
     --network object                            (properties: associate_public_ip, interface and vpc)
                                                 Use --network=help for more details
+    --network-profile object                    (single property: interfaces)
+                                                Use --network-profile=help for more details
+    --network-profile.interfaces array          network-profile's interfaces property: Interfaces (at most 3 items)
+                                                Use --network-profile.interfaces=help for more details
+                                                This is the same as '--network-profile=interfaces:array'.
     --network.associate-public-ip boolean       network's associate_public_ip property: Associate Public Ip
                                                 This is the same as '--network=associate_public_ip:boolean'.
-    --network.interface object                  network's interface property: Interface (at least one of: single property: id or single property: security_groups)
+    --network.interface object                  network's interface property: Interface (at least one of: single property: id or properties: security_groups and subnets)
                                                 Use --network.interface=help for more details
                                                 This is the same as '--network=interface:object'.
     --network.interface.id string               Interface: Id (between 1 and 255 characters)
@@ -46,6 +51,9 @@ mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d9
     --network.interface.security-groups array   Interface: Security Groups
                                                 Use --network.interface.security-groups=help for more details
                                                 This is the same as '--network.interface=security_groups:array'.
+    --network.interface.subnets array           Interface: Subnets (at most 1 item)
+                                                Use --network.interface.subnets=help for more details
+                                                This is the same as '--network.interface=subnets:array'.
     --network.vpc object                        network's vpc property: Vpc (at least one of: single property: id or single property: name)
                                                 Use --network.vpc=help for more details
                                                 This is the same as '--network=vpc:object'.

--- a/mgc/cli/docs/virtual-machine/snapshots/restore.md
+++ b/mgc/cli/docs/virtual-machine/snapshots/restore.md
@@ -12,7 +12,7 @@ mgc virtual-machine snapshots restore [id] [flags]
 
 ## Examples:
 ```
-mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name"
+mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.interface.subnets='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name"
 ```
 
 ## Flags:
@@ -32,7 +32,7 @@ mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111
                                                 Use --network=help for more details
     --network.associate-public-ip boolean       network's associate_public_ip property: Associate Public Ip
                                                 This is the same as '--network=associate_public_ip:boolean'.
-    --network.interface object                  network's interface property: Interface (at least one of: single property: id or single property: security_groups)
+    --network.interface object                  network's interface property: Interface (at least one of: single property: id or properties: security_groups and subnets)
                                                 Use --network.interface=help for more details
                                                 This is the same as '--network=interface:object'.
     --network.interface.id string               Interface: Id (between 1 and 255 characters)
@@ -40,6 +40,9 @@ mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111
     --network.interface.security-groups array   Interface: Security Groups
                                                 Use --network.interface.security-groups=help for more details
                                                 This is the same as '--network.interface=security_groups:array'.
+    --network.interface.subnets array           Interface: Subnets (at most 1 item)
+                                                Use --network.interface.subnets=help for more details
+                                                This is the same as '--network.interface=subnets:array'.
     --network.vpc object                        network's vpc property: Vpc (at least one of: single property: id or single property: name)
                                                 Use --network.vpc=help for more details
                                                 This is the same as '--network=vpc:object'.

--- a/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
@@ -72,11 +72,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.images[*].id,NAME:$.images[*].name,VERSION:$.images[*].version,PLATFORM:$.images[*].platform,END_STANDARD_SUPPORT_AT:$.images[*].end_standard_support_at,STATUS:$.images[*].status,AVAILABILITY_ZONES:$.images[*].availability_zones
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.images[*].id,NAME:$.images[*].name,VERSION:$.images[*].version,PLATFORM:$.images[*].platform,END_STANDARD_SUPPORT_AT:$.images[*].end_standard_support_at,STATUS:$.images[*].status,AVAILABILITY_ZONES:$.images[*].availability_zones
     /v1/images/custom:
         get:
             tags:
@@ -133,10 +133,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
         post:
             tags:
             - images
@@ -178,10 +178,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
     /v1/images/custom/{id}:
         get:
             tags:
@@ -220,10 +220,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
         delete:
             tags:
             - images
@@ -247,10 +247,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
         patch:
             tags:
             - images
@@ -291,10 +291,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
     /v1/instance-types:
         get:
             tags:
@@ -368,12 +368,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-mgc-hidden: true
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-mgc-hidden: true
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu
     /v1/instances:
         get:
             tags:
@@ -494,12 +494,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.instances[*].id,NAME:$.instances[*].name,STATE:$.instances[*].state,STATUS:$.instances[*].status,MACHINE_TYPE:$.instances[*].machine_type,IMAGE:$.instances[*].image,
-                CREATED_AT:$.instances[*].created_at, SSH_KEY_NAME:$.instances[*].ssh_key_name
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.instances[*].id,NAME:$.instances[*].name,STATE:$.instances[*].state,STATUS:$.instances[*].status,MACHINE_TYPE:$.instances[*].machine_type,IMAGE:$.instances[*].image,
+                CREATED_AT:$.instances[*].created_at, SSH_KEY_NAME:$.instances[*].ssh_key_name
         post:
             tags:
             - instances
@@ -619,11 +619,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.id
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.id
     /v1/instances/config/{id}/first-windows-password:
         get:
             tags:
@@ -749,10 +749,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
     /v1/instances/network-interface/detach:
         post:
             tags:
@@ -800,10 +800,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
     /v1/instances/{id}:
         get:
             tags:
@@ -959,12 +959,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$..status,MACHINE_TYPE:$.machine_type,IMAGE:$.image,
-                CREATED_AT:$.created_at, SSH_KEY_NAME:$.ssh_key_name
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$..status,MACHINE_TYPE:$.machine_type,IMAGE:$.image,
+                CREATED_AT:$.created_at, SSH_KEY_NAME:$.ssh_key_name
         delete:
             tags:
             - instances
@@ -1043,10 +1043,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
     /v1/instances/{id}/init-logs:
         get:
             tags:
@@ -1224,11 +1224,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-name: reboot
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-name: reboot
     /v1/instances/{id}/rename:
         patch:
             tags:
@@ -1345,10 +1345,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
     /v1/instances/{id}/retype:
         post:
             tags:
@@ -1484,11 +1484,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-name: retype
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-name: retype
     /v1/instances/{id}/start:
         post:
             tags:
@@ -1575,11 +1575,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-name: start
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-name: start
     /v1/instances/{id}/stop:
         post:
             tags:
@@ -1667,11 +1667,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-name: stop
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-name: stop
     /v1/instances/{id}/suspend:
         post:
             tags:
@@ -1760,11 +1760,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-name: suspend
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-name: suspend
     /v1/machine-types:
         get:
             tags:
@@ -1838,11 +1838,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu
     /v1/snapshots:
         get:
             tags:
@@ -1950,12 +1950,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.snapshots[*].id,NAME:$.snapshots[*].name,STATE:$.snapshots[*].state,STATUS:$.snapshots[*].status,SIZE:$.snapshots[*].size,INSTANCE:$.snapshots[*].instance,
-                CREATED_AT:$.snapshots[*].created_at
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.snapshots[*].id,NAME:$.snapshots[*].name,STATE:$.snapshots[*].state,STATUS:$.snapshots[*].status,SIZE:$.snapshots[*].size,INSTANCE:$.snapshots[*].instance,
+                CREATED_AT:$.snapshots[*].created_at
         post:
             tags:
             - snapshots
@@ -2052,11 +2052,11 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.id
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.id
     /v1/snapshots/{id}:
         get:
             tags:
@@ -2162,12 +2162,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-output-flag: table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$.status,SIZE:$.size,INSTANCE:$.instance,
-                CREATED_AT:$.created_at
             security:
             -   OAuth2:
                 - virtual-machine.read
+            x-viveiro: true
+            x-mgc-output-flag: table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$.status,SIZE:$.size,INSTANCE:$.instance,
+                CREATED_AT:$.created_at
         post:
             tags:
             - snapshots
@@ -2265,12 +2265,12 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
-            x-mgc-name: restore
-            x-mgc-output-flag: table=ID:$.id
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
+            x-mgc-name: restore
+            x-mgc-output-flag: table=ID:$.id
         delete:
             tags:
             - snapshots
@@ -2329,10 +2329,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
     /v1/snapshots/{id}/copy:
         post:
             tags:
@@ -2409,10 +2409,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: false
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: false
     /v1/snapshots/{id}/rename:
         patch:
             tags:
@@ -2501,10 +2501,10 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/HTTPValidationError'
-            x-viveiro: true
             security:
             -   OAuth2:
                 - virtual-machine.write
+            x-viveiro: true
 components:
     schemas:
         Architecture:
@@ -2583,9 +2583,9 @@ components:
                 name: my-linux-image-3
                 platform: linux
                 requirements:
-                    disk: 100
-                    ram: 8
-                    vcpu: 4
+                    disk: 10
+                    ram: 1
+                    vcpu: 1
                 uefi: true
                 url: https://br-se1.magaluobjects.com/bucket/image.qcow2
                 version: '2.1'
@@ -2671,6 +2671,8 @@ components:
                     - pending
                     - creating
                     - importing
+                    - importing_error
+                    - invalid_image
                     - error
                 description:
                     anyOf:
@@ -2823,6 +2825,8 @@ components:
                     - pending
                     - creating
                     - importing
+                    - importing_error
+                    - invalid_image
                     - error
                 version:
                     anyOf:
@@ -2931,6 +2935,8 @@ components:
             - pending
             - creating
             - importing
+            - importing_error
+            - invalid_image
             - error
         InstanceAccessResponseWithPass:
             type: object
@@ -3030,6 +3036,10 @@ components:
                     anyOf:
                     -   $ref: '#/components/schemas/InstanceCreateRequestV1NetworkDefault'
                     nullable: true
+                network_profile:
+                    anyOf:
+                    -   $ref: '#/components/schemas/InstanceCreateRequestV2NetworkBase'
+                    nullable: true
                 user_data:
                     anyOf:
                     -   type: string
@@ -3074,8 +3084,22 @@ components:
                         security_groups:
                         -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                         -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                        subnets:
+                        -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                     vpc:
                         id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
+                network_profile:
+                    interfaces:
+                    -   associate_public_ip: true
+                        name: nic-name
+                        security_groups:
+                        -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
+                        -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                        subnets:
+                        -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
+                        tag: primary
+                        vpc:
+                            id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
                 ssh_key_name: keypair_name_here
                 user_data: some_base64_script
                 volumes:
@@ -3094,7 +3118,7 @@ components:
                 interface:
                     anyOf:
                     -   $ref: '#/components/schemas/ID'
-                    -   $ref: '#/components/schemas/SecurityGroups'
+                    -   $ref: '#/components/schemas/Interface'
                     title: Interface
                     nullable: true
                 associate_public_ip:
@@ -3108,8 +3132,109 @@ components:
                     security_groups:
                     -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                     -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                    subnets:
+                    -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                 vpc:
                     id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
+        InstanceCreateRequestV2NetworkBase:
+            type: object
+            properties:
+                interfaces:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            id:
+                                anyOf:
+                                -   $ref: '#/components/schemas/ID'
+                                description: The unique identifier of the network
+                                    interface.
+                                nullable: true
+                            name:
+                                anyOf:
+                                -   type: string
+                                title: Name
+                                description: A human-readable name assigned to the
+                                    network interface.
+                                nullable: true
+                            vpc:
+                                anyOf:
+                                -   $ref: '#/components/schemas/ID'
+                                -   $ref: '#/components/schemas/Name'
+                                title: Vpc
+                                description: The Virtual Private Cloud (VPC) where
+                                    this interface will be attached.
+                                default:
+                                    name: vpc_default
+                                nullable: true
+                            subnets:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        id:
+                                            type: string
+                                            title: Id
+                                            maxLength: 255
+                                            minLength: 1
+                                    title: ID
+                                    required:
+                                    - id
+                                    example:
+                                        id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                                title: Subnets
+                                maxItems: 1
+                                description: A list containing the subnet ID associated
+                                    with this interface (maximum of 1 subnet).
+                            security_groups:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        id:
+                                            type: string
+                                            title: Id
+                                            maxLength: 255
+                                            minLength: 1
+                                    title: ID
+                                    required:
+                                    - id
+                                    example:
+                                        id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                                title: Security Groups
+                                description: A list of security group IDs applied
+                                    to this network interface for traffic filtering.
+                                default: []
+                            associate_public_ip:
+                                type: boolean
+                                title: Associate Public Ip
+                                description: Indicates whether a public IP address
+                                    should be automatically assigned to this interface.
+                                default: false
+                            tag:
+                                anyOf:
+                                -   type: string
+                                title: Tag
+                                description: An optional device role tag exposed to
+                                    the guest OS via metadata. It ensures reliable
+                                    interface identification, as network device order
+                                    is not guaranteed.
+                                nullable: true
+                        title: NetworkInterfaceAttachment
+                    title: Interfaces
+                    maxItems: 3
+            title: InstanceCreateRequestV2NetworkBase
+            example:
+                interfaces:
+                -   associate_public_ip: true
+                    security_groups:
+                    -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
+                    -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                    subnets:
+                    -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
+                    tag: primary
+                    vpc:
+                        id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
         InstanceResponseSnapshotV1:
             type: object
             properties:
@@ -3390,6 +3515,7 @@ components:
                     - creating
                     - creating_error
                     - creating_error_gpu
+                    - creating_error_capacity
                     - creating_network_error
                     - creating_error_quota
                     - creating_error_quota_ram
@@ -3406,6 +3532,7 @@ components:
                     - retyping_error_quota_ram
                     - retyping_error_quota_vcpu
                     - retyping_error_quota
+                    - retyping_error_capacity
                     - stopping_pending
                     - stopping
                     - stopping_error
@@ -3533,6 +3660,7 @@ components:
             - creating
             - creating_error
             - creating_error_gpu
+            - creating_error_capacity
             - creating_network_error
             - creating_error_quota
             - creating_error_quota_ram
@@ -3549,6 +3677,7 @@ components:
             - retyping_error_quota_ram
             - retyping_error_quota_vcpu
             - retyping_error_quota
+            - retyping_error_capacity
             - stopping_pending
             - stopping
             - stopping_error
@@ -3580,6 +3709,44 @@ components:
             - name
             example:
                 name: new-instance-name
+        Interface:
+            type: object
+            properties:
+                security_groups:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                                title: Id
+                                maxLength: 255
+                                minLength: 1
+                        title: ID
+                        required:
+                        - id
+                        example:
+                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                    title: Security Groups
+                    default: []
+                subnets:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                                title: Id
+                                maxLength: 255
+                                minLength: 1
+                        title: ID
+                        required:
+                        - id
+                        example:
+                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                    title: Subnets
+                    maxItems: 1
+            title: Interface
         IpAddressExpand:
             type: object
             properties:
@@ -3645,6 +3812,8 @@ components:
                                 - pending
                                 - creating
                                 - importing
+                                - importing_error
+                                - invalid_image
                                 - error
                             description:
                                 anyOf:
@@ -3892,6 +4061,83 @@ components:
             - name
             example:
                 name: some_resource_name
+        NetworkInterfaceAttachment:
+            type: object
+            properties:
+                id:
+                    anyOf:
+                    -   $ref: '#/components/schemas/ID'
+                    description: The unique identifier of the network interface.
+                    nullable: true
+                name:
+                    anyOf:
+                    -   type: string
+                    title: Name
+                    description: A human-readable name assigned to the network interface.
+                    nullable: true
+                vpc:
+                    anyOf:
+                    -   $ref: '#/components/schemas/ID'
+                    -   $ref: '#/components/schemas/Name'
+                    title: Vpc
+                    description: The Virtual Private Cloud (VPC) where this interface
+                        will be attached.
+                    default:
+                        name: vpc_default
+                    nullable: true
+                subnets:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                                title: Id
+                                maxLength: 255
+                                minLength: 1
+                        title: ID
+                        required:
+                        - id
+                        example:
+                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                    title: Subnets
+                    maxItems: 1
+                    description: A list containing the subnet ID associated with this
+                        interface (maximum of 1 subnet).
+                security_groups:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                                title: Id
+                                maxLength: 255
+                                minLength: 1
+                        title: ID
+                        required:
+                        - id
+                        example:
+                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                    title: Security Groups
+                    description: A list of security group IDs applied to this network
+                        interface for traffic filtering.
+                    default: []
+                associate_public_ip:
+                    type: boolean
+                    title: Associate Public Ip
+                    description: Indicates whether a public IP address should be automatically
+                        assigned to this interface.
+                    default: false
+                tag:
+                    anyOf:
+                    -   type: string
+                    title: Tag
+                    description: An optional device role tag exposed to the guest
+                        OS via metadata. It ensures reliable interface identification,
+                        as network device order is not guaranteed.
+                    nullable: true
+            title: NetworkInterfaceAttachment
         NetworkPortsNew:
             type: object
             properties:
@@ -3950,6 +4196,11 @@ components:
                                     anyOf:
                                     -   $ref: '#/components/schemas/IpAddressNewExpand'
                                     nullable: true
+                                mac_address:
+                                    anyOf:
+                                    -   type: string
+                                    title: Mac Address
+                                    nullable: true
                             title: PortNewExpand
                             required:
                             - id
@@ -3996,6 +4247,11 @@ components:
                                 name:
                                     type: string
                                     title: Name
+                                vpc_id:
+                                    anyOf:
+                                    -   type: string
+                                    title: Vpc Id
+                                    nullable: true
                                 ipAddresses:
                                     type: object
                                     properties:
@@ -4015,6 +4271,11 @@ components:
                                             title: Ipv6Address
                                             nullable: true
                                     title: IpAddressExpand
+                                mac_address:
+                                    anyOf:
+                                    -   type: string
+                                    title: Mac Address
+                                    nullable: true
                             title: PortV1Expand
                             required:
                             - id
@@ -4211,6 +4472,8 @@ components:
                                 - pending
                                 - creating
                                 - importing
+                                - importing_error
+                                - invalid_image
                                 - error
                             version:
                                 anyOf:
@@ -4396,6 +4659,7 @@ components:
                                 - creating
                                 - creating_error
                                 - creating_error_gpu
+                                - creating_error_capacity
                                 - creating_network_error
                                 - creating_error_quota
                                 - creating_error_quota_ram
@@ -4412,6 +4676,7 @@ components:
                                 - retyping_error_quota_ram
                                 - retyping_error_quota_vcpu
                                 - retyping_error_quota
+                                - retyping_error_capacity
                                 - stopping_pending
                                 - stopping
                                 - stopping_error
@@ -4709,7 +4974,9 @@ components:
                 requirements:
                     anyOf:
                     -   $ref: '#/components/schemas/CustomImageRequirements'
+                    description: 'Deprecated: this field is ignored.'
                     nullable: true
+                    deprecated: true
             title: PatchCustomImageRequest
             example:
                 description: A customized image for specific workloads.
@@ -4763,6 +5030,11 @@ components:
                     anyOf:
                     -   $ref: '#/components/schemas/IpAddressNewExpand'
                     nullable: true
+                mac_address:
+                    anyOf:
+                    -   type: string
+                    title: Mac Address
+                    nullable: true
             title: PortNewExpand
             required:
             - id
@@ -4776,6 +5048,11 @@ components:
                 name:
                     type: string
                     title: Name
+                vpc_id:
+                    anyOf:
+                    -   type: string
+                    title: Vpc Id
+                    nullable: true
                 ipAddresses:
                     type: object
                     properties:
@@ -4795,6 +5072,11 @@ components:
                             title: Ipv6Address
                             nullable: true
                     title: IpAddressExpand
+                mac_address:
+                    anyOf:
+                    -   type: string
+                    title: Mac Address
+                    nullable: true
             title: PortV1Expand
             required:
             - id
@@ -4807,27 +5089,6 @@ components:
             - br-se1
             - br-mgl1
             - br-ne1
-        SecurityGroups:
-            type: object
-            properties:
-                security_groups:
-                    type: array
-                    items:
-                        type: object
-                        properties:
-                            id:
-                                type: string
-                                title: Id
-                                maxLength: 255
-                                minLength: 1
-                        title: ID
-                        required:
-                        - id
-                        example:
-                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
-                    title: Security Groups
-                    default: []
-            title: SecurityGroups
         SnapshotCopyRequest:
             type: object
             properties:
@@ -4985,6 +5246,8 @@ components:
                         security_groups:
                         -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                         -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                        subnets:
+                        -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                     vpc:
                         id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
                 ssh_key_name: keypair_name_here

--- a/specs/conv.virtual-machine.jaxyendy.openapi.json
+++ b/specs/conv.virtual-machine.jaxyendy.openapi.json
@@ -116,6 +116,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.images[*].id,NAME:$.images[*].name,VERSION:$.images[*].version,PLATFORM:$.images[*].platform,END_STANDARD_SUPPORT_AT:$.images[*].end_standard_support_at,STATUS:$.images[*].status,AVAILABILITY_ZONES:$.images[*].availability_zones"
       }
@@ -211,6 +218,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true
       },
       "post": {
@@ -263,6 +277,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -316,6 +337,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true
       },
       "delete": {
@@ -361,6 +389,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       },
       "patch": {
@@ -416,6 +451,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -532,6 +574,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-mgc-hidden": true,
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu"
@@ -705,6 +754,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.instances[*].id,NAME:$.instances[*].name,STATE:$.instances[*].state,STATUS:$.instances[*].status,MACHINE_TYPE:$.instances[*].machine_type,IMAGE:$.instances[*].image, CREATED_AT:$.instances[*].created_at, SSH_KEY_NAME:$.instances[*].ssh_key_name"
       },
@@ -798,6 +854,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id"
       }
@@ -939,6 +1002,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1026,6 +1096,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1152,6 +1229,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$..status,MACHINE_TYPE:$.machine_type,IMAGE:$.image, CREATED_AT:$.created_at, SSH_KEY_NAME:$.ssh_key_name"
       },
@@ -1252,6 +1336,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1368,6 +1459,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "reboot"
       }
@@ -1467,6 +1565,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1566,6 +1671,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "retype"
       }
@@ -1616,6 +1728,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "start"
       }
@@ -1666,6 +1785,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "stop"
       }
@@ -1716,6 +1842,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "suspend"
       }
@@ -1833,6 +1966,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu"
       }
@@ -1989,6 +2129,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.snapshots[*].id,NAME:$.snapshots[*].name,STATE:$.snapshots[*].state,STATUS:$.snapshots[*].status,SIZE:$.snapshots[*].size,INSTANCE:$.snapshots[*].instance, CREATED_AT:$.snapshots[*].created_at"
       },
@@ -2082,6 +2229,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id"
       }
@@ -2191,6 +2345,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$.status,SIZE:$.size,INSTANCE:$.instance, CREATED_AT:$.created_at"
       },
@@ -2293,6 +2454,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "restore",
         "x-mgc-output-flag": "table=ID:$.id"
@@ -2380,6 +2548,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -2477,6 +2652,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": false
       }
     },
@@ -2573,6 +2755,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     }
@@ -2682,9 +2871,9 @@
           "name": "my-linux-image-3",
           "platform": "linux",
           "requirements": {
-            "disk": 100,
-            "ram": 8,
-            "vcpu": 4
+            "disk": 10,
+            "ram": 1,
+            "vcpu": 1
           },
           "uefi": true,
           "url": "https://br-se1.magaluobjects.com/bucket/image.qcow2",
@@ -2798,6 +2987,8 @@
               "pending",
               "creating",
               "importing",
+              "importing_error",
+              "invalid_image",
               "error"
             ]
           },
@@ -3036,6 +3227,8 @@
               "pending",
               "creating",
               "importing",
+              "importing_error",
+              "invalid_image",
               "error"
             ]
           },
@@ -3194,6 +3387,8 @@
           "pending",
           "creating",
           "importing",
+          "importing_error",
+          "invalid_image",
           "error"
         ]
       },
@@ -3341,6 +3536,14 @@
             ],
             "nullable": true
           },
+          "network_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InstanceCreateRequestV2NetworkBase"
+              }
+            ],
+            "nullable": true
+          },
           "user_data": {
             "anyOf": [
               {
@@ -3413,11 +3616,41 @@
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
                 }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                }
               ]
             },
             "vpc": {
               "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
             }
+          },
+          "network_profile": {
+            "interfaces": [
+              {
+                "associate_public_ip": true,
+                "name": "nic-name",
+                "security_groups": [
+                  {
+                    "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                  },
+                  {
+                    "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+                  }
+                ],
+                "subnets": [
+                  {
+                    "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                  }
+                ],
+                "tag": "primary",
+                "vpc": {
+                  "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
+                }
+              }
+            ]
           },
           "ssh_key_name": "keypair_name_here",
           "user_data": "some_base64_script",
@@ -3452,7 +3685,7 @@
                 "$ref": "#/components/schemas/ID"
               },
               {
-                "$ref": "#/components/schemas/SecurityGroups"
+                "$ref": "#/components/schemas/Interface"
               }
             ],
             "title": "Interface",
@@ -3475,11 +3708,156 @@
               {
                 "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
               }
+            ],
+            "subnets": [
+              {
+                "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+              }
             ]
           },
           "vpc": {
             "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
           }
+        }
+      },
+      "InstanceCreateRequestV2NetworkBase": {
+        "type": "object",
+        "properties": {
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ID"
+                    }
+                  ],
+                  "description": "The unique identifier of the network interface.",
+                  "nullable": true
+                },
+                "name": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "title": "Name",
+                  "description": "A human-readable name assigned to the network interface.",
+                  "nullable": true
+                },
+                "vpc": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ID"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Name"
+                    }
+                  ],
+                  "title": "Vpc",
+                  "description": "The Virtual Private Cloud (VPC) where this interface will be attached.",
+                  "default": {
+                    "name": "vpc_default"
+                  },
+                  "nullable": true
+                },
+                "subnets": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "title": "Id",
+                        "maxLength": 255,
+                        "minLength": 1
+                      }
+                    },
+                    "title": "ID",
+                    "required": [
+                      "id"
+                    ],
+                    "example": {
+                      "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+                    }
+                  },
+                  "title": "Subnets",
+                  "maxItems": 1,
+                  "description": "A list containing the subnet ID associated with this interface (maximum of 1 subnet)."
+                },
+                "security_groups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "title": "Id",
+                        "maxLength": 255,
+                        "minLength": 1
+                      }
+                    },
+                    "title": "ID",
+                    "required": [
+                      "id"
+                    ],
+                    "example": {
+                      "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+                    }
+                  },
+                  "title": "Security Groups",
+                  "description": "A list of security group IDs applied to this network interface for traffic filtering.",
+                  "default": []
+                },
+                "associate_public_ip": {
+                  "type": "boolean",
+                  "title": "Associate Public Ip",
+                  "description": "Indicates whether a public IP address should be automatically assigned to this interface.",
+                  "default": false
+                },
+                "tag": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "title": "Tag",
+                  "description": "An optional device role tag exposed to the guest OS via metadata. It ensures reliable interface identification, as network device order is not guaranteed.",
+                  "nullable": true
+                }
+              },
+              "title": "NetworkInterfaceAttachment"
+            },
+            "title": "Interfaces",
+            "maxItems": 3
+          }
+        },
+        "title": "InstanceCreateRequestV2NetworkBase",
+        "example": {
+          "interfaces": [
+            {
+              "associate_public_ip": true,
+              "security_groups": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                },
+                {
+                  "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+                }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                }
+              ],
+              "tag": "primary",
+              "vpc": {
+                "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
+              }
+            }
+          ]
         }
       },
       "InstanceResponseSnapshotV1": {
@@ -3875,6 +4253,7 @@
               "creating",
               "creating_error",
               "creating_error_gpu",
+              "creating_error_capacity",
               "creating_network_error",
               "creating_error_quota",
               "creating_error_quota_ram",
@@ -3891,6 +4270,7 @@
               "retyping_error_quota_ram",
               "retyping_error_quota_vcpu",
               "retyping_error_quota",
+              "retyping_error_capacity",
               "stopping_pending",
               "stopping",
               "stopping_error",
@@ -4071,6 +4451,7 @@
           "creating",
           "creating_error",
           "creating_error_gpu",
+          "creating_error_capacity",
           "creating_network_error",
           "creating_error_quota",
           "creating_error_quota_ram",
@@ -4087,6 +4468,7 @@
           "retyping_error_quota_ram",
           "retyping_error_quota_vcpu",
           "retyping_error_quota",
+          "retyping_error_capacity",
           "stopping_pending",
           "stopping",
           "stopping_error",
@@ -4124,6 +4506,58 @@
         "example": {
           "name": "new-instance-name"
         }
+      },
+      "Interface": {
+        "type": "object",
+        "properties": {
+          "security_groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "maxLength": 255,
+                  "minLength": 1
+                }
+              },
+              "title": "ID",
+              "required": [
+                "id"
+              ],
+              "example": {
+                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+              }
+            },
+            "title": "Security Groups",
+            "default": []
+          },
+          "subnets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "maxLength": 255,
+                  "minLength": 1
+                }
+              },
+              "title": "ID",
+              "required": [
+                "id"
+              ],
+              "example": {
+                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+              }
+            },
+            "title": "Subnets",
+            "maxItems": 1
+          }
+        },
+        "title": "Interface"
       },
       "IpAddressExpand": {
         "type": "object",
@@ -4218,6 +4652,8 @@
                     "pending",
                     "creating",
                     "importing",
+                    "importing_error",
+                    "invalid_image",
                     "error"
                   ]
                 },
@@ -4575,6 +5011,111 @@
           "name": "some_resource_name"
         }
       },
+      "NetworkInterfaceAttachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              }
+            ],
+            "description": "The unique identifier of the network interface.",
+            "nullable": true
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Name",
+            "description": "A human-readable name assigned to the network interface.",
+            "nullable": true
+          },
+          "vpc": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "$ref": "#/components/schemas/Name"
+              }
+            ],
+            "title": "Vpc",
+            "description": "The Virtual Private Cloud (VPC) where this interface will be attached.",
+            "default": {
+              "name": "vpc_default"
+            },
+            "nullable": true
+          },
+          "subnets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "maxLength": 255,
+                  "minLength": 1
+                }
+              },
+              "title": "ID",
+              "required": [
+                "id"
+              ],
+              "example": {
+                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+              }
+            },
+            "title": "Subnets",
+            "maxItems": 1,
+            "description": "A list containing the subnet ID associated with this interface (maximum of 1 subnet)."
+          },
+          "security_groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "maxLength": 255,
+                  "minLength": 1
+                }
+              },
+              "title": "ID",
+              "required": [
+                "id"
+              ],
+              "example": {
+                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+              }
+            },
+            "title": "Security Groups",
+            "description": "A list of security group IDs applied to this network interface for traffic filtering.",
+            "default": []
+          },
+          "associate_public_ip": {
+            "type": "boolean",
+            "title": "Associate Public Ip",
+            "description": "Indicates whether a public IP address should be automatically assigned to this interface.",
+            "default": false
+          },
+          "tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Tag",
+            "description": "An optional device role tag exposed to the guest OS via metadata. It ensures reliable interface identification, as network device order is not guaranteed.",
+            "nullable": true
+          }
+        },
+        "title": "NetworkInterfaceAttachment"
+      },
       "NetworkPortsNew": {
         "type": "object",
         "properties": {
@@ -4659,6 +5200,15 @@
                         }
                       ],
                       "nullable": true
+                    },
+                    "mac_address": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "title": "Mac Address",
+                      "nullable": true
                     }
                   },
                   "title": "PortNewExpand",
@@ -4730,6 +5280,15 @@
                       "type": "string",
                       "title": "Name"
                     },
+                    "vpc_id": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "title": "Vpc Id",
+                      "nullable": true
+                    },
                     "ipAddresses": {
                       "type": "object",
                       "properties": {
@@ -4762,6 +5321,15 @@
                         }
                       },
                       "title": "IpAddressExpand"
+                    },
+                    "mac_address": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "title": "Mac Address",
+                      "nullable": true
                     }
                   },
                   "title": "PortV1Expand",
@@ -5031,6 +5599,8 @@
                     "pending",
                     "creating",
                     "importing",
+                    "importing_error",
+                    "invalid_image",
                     "error"
                   ]
                 },
@@ -5301,6 +5871,7 @@
                     "creating",
                     "creating_error",
                     "creating_error_gpu",
+                    "creating_error_capacity",
                     "creating_network_error",
                     "creating_error_quota",
                     "creating_error_quota_ram",
@@ -5317,6 +5888,7 @@
                     "retyping_error_quota_ram",
                     "retyping_error_quota_vcpu",
                     "retyping_error_quota",
+                    "retyping_error_capacity",
                     "stopping_pending",
                     "stopping",
                     "stopping_error",
@@ -5749,7 +6321,9 @@
                 "$ref": "#/components/schemas/CustomImageRequirements"
               }
             ],
-            "nullable": true
+            "description": "Deprecated: this field is ignored.",
+            "nullable": true,
+            "deprecated": true
           }
         },
         "title": "PatchCustomImageRequest",
@@ -5827,6 +6401,15 @@
               }
             ],
             "nullable": true
+          },
+          "mac_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Mac Address",
+            "nullable": true
           }
         },
         "title": "PortNewExpand",
@@ -5845,6 +6428,15 @@
           "name": {
             "type": "string",
             "title": "Name"
+          },
+          "vpc_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Vpc Id",
+            "nullable": true
           },
           "ipAddresses": {
             "type": "object",
@@ -5878,6 +6470,15 @@
               }
             },
             "title": "IpAddressExpand"
+          },
+          "mac_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Mac Address",
+            "nullable": true
           }
         },
         "title": "PortV1Expand",
@@ -5895,35 +6496,6 @@
           "br-mgl1",
           "br-ne1"
         ]
-      },
-      "SecurityGroups": {
-        "type": "object",
-        "properties": {
-          "security_groups": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "title": "Id",
-                  "maxLength": 255,
-                  "minLength": 1
-                }
-              },
-              "title": "ID",
-              "required": [
-                "id"
-              ],
-              "example": {
-                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
-              }
-            },
-            "title": "Security Groups",
-            "default": []
-          }
-        },
-        "title": "SecurityGroups"
       },
       "SnapshotCopyRequest": {
         "type": "object",
@@ -6158,6 +6730,11 @@
                 },
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+                }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
                 }
               ]
             },

--- a/specs/virtual-machine.jaxyendy.openapi.json
+++ b/specs/virtual-machine.jaxyendy.openapi.json
@@ -121,6 +121,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.images[*].id,NAME:$.images[*].name,VERSION:$.images[*].version,PLATFORM:$.images[*].platform,END_STANDARD_SUPPORT_AT:$.images[*].end_standard_support_at,STATUS:$.images[*].status,AVAILABILITY_ZONES:$.images[*].availability_zones"
       }
@@ -219,6 +226,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true
       },
       "post": {
@@ -271,6 +285,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -324,6 +345,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true
       },
       "delete": {
@@ -369,6 +397,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       },
       "patch": {
@@ -424,6 +459,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -545,6 +587,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-mgc-hidden": true,
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu"
@@ -723,6 +772,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.instances[*].id,NAME:$.instances[*].name,STATE:$.instances[*].state,STATUS:$.instances[*].status,MACHINE_TYPE:$.instances[*].machine_type,IMAGE:$.instances[*].image, CREATED_AT:$.instances[*].created_at, SSH_KEY_NAME:$.instances[*].ssh_key_name"
       },
@@ -816,6 +872,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id"
       }
@@ -957,6 +1020,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1044,6 +1114,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1172,6 +1249,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$..status,MACHINE_TYPE:$.machine_type,IMAGE:$.image, CREATED_AT:$.created_at, SSH_KEY_NAME:$.ssh_key_name"
       },
@@ -1272,6 +1356,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1388,6 +1479,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "reboot"
       }
@@ -1487,6 +1585,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -1586,6 +1691,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "retype"
       }
@@ -1636,6 +1748,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "start"
       }
@@ -1686,6 +1805,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "stop"
       }
@@ -1736,6 +1862,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "suspend"
       }
@@ -1858,6 +1991,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.instance_types[*].id,NAME:$.instance_types[*].name,STATUS:$.instance_types[*].status,VCPUS:$.instance_types[*].vcpus,RAM:$.instance_types[*].ram,DISK:$.instance_types[*].disk,GPU:$.instance_types[*].gpu"
       }
@@ -2017,6 +2157,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.snapshots[*].id,NAME:$.snapshots[*].name,STATE:$.snapshots[*].state,STATUS:$.snapshots[*].status,SIZE:$.snapshots[*].size,INSTANCE:$.snapshots[*].instance, CREATED_AT:$.snapshots[*].created_at"
       },
@@ -2110,6 +2257,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id"
       }
@@ -2219,6 +2373,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.read"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-output-flag": "table=ID:$.id,NAME:$.name,STATE:$.state,STATUS:$.status,SIZE:$.size,INSTANCE:$.instance, CREATED_AT:$.created_at"
       },
@@ -2321,6 +2482,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true,
         "x-mgc-name": "restore",
         "x-mgc-output-flag": "table=ID:$.id"
@@ -2408,6 +2576,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     },
@@ -2505,6 +2680,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": false
       }
     },
@@ -2601,6 +2783,13 @@
             }
           }
         },
+        "security": [
+          {
+            "OAuth2": [
+              "virtual-machine.write"
+            ]
+          }
+        ],
         "x-viveiro": true
       }
     }
@@ -2648,7 +2837,9 @@
             "title": "Url"
           },
           "requirements": {
-            "$ref": "#/components/schemas/CustomImageRequirements"
+            "$ref": "#/components/schemas/CustomImageRequirements",
+            "description": "Deprecated: this field is ignored.",
+            "deprecated": true
           },
           "platform": {
             "$ref": "#/components/schemas/Platform"
@@ -2680,9 +2871,9 @@
           "name": "my-linux-image-3",
           "platform": "linux",
           "requirements": {
-            "disk": 100,
-            "ram": 8,
-            "vcpu": 4
+            "disk": 10,
+            "ram": 1,
+            "vcpu": 1
           },
           "uefi": true,
           "url": "https://br-se1.magaluobjects.com/bucket/image.qcow2",
@@ -3141,6 +3332,8 @@
           "pending",
           "creating",
           "importing",
+          "importing_error",
+          "invalid_image",
           "error"
         ]
       },
@@ -3270,6 +3463,16 @@
               "associate_public_ip": true
             }
           },
+          "network_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InstanceCreateRequestV2NetworkBase"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "user_data": {
             "anyOf": [
               {
@@ -3348,11 +3551,41 @@
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
                 }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                }
               ]
             },
             "vpc": {
               "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
             }
+          },
+          "network_profile": {
+            "interfaces": [
+              {
+                "associate_public_ip": true,
+                "name": "nic-name",
+                "security_groups": [
+                  {
+                    "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                  },
+                  {
+                    "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+                  }
+                ],
+                "subnets": [
+                  {
+                    "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                  }
+                ],
+                "tag": "primary",
+                "vpc": {
+                  "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
+                }
+              }
+            ]
           },
           "ssh_key_name": "keypair_name_here",
           "user_data": "some_base64_script",
@@ -3389,7 +3622,7 @@
                 "$ref": "#/components/schemas/ID"
               },
               {
-                "$ref": "#/components/schemas/SecurityGroups"
+                "$ref": "#/components/schemas/Interface"
               },
               {
                 "type": "null"
@@ -3414,11 +3647,54 @@
               {
                 "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
               }
+            ],
+            "subnets": [
+              {
+                "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+              }
             ]
           },
           "vpc": {
             "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
           }
+        }
+      },
+      "InstanceCreateRequestV2NetworkBase": {
+        "type": "object",
+        "properties": {
+          "interfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkInterfaceAttachment"
+            },
+            "title": "Interfaces",
+            "maxItems": 3
+          }
+        },
+        "title": "InstanceCreateRequestV2NetworkBase",
+        "example": {
+          "interfaces": [
+            {
+              "associate_public_ip": true,
+              "security_groups": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                },
+                {
+                  "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+                }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                }
+              ],
+              "tag": "primary",
+              "vpc": {
+                "id": "2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6"
+              }
+            }
+          ]
         }
       },
       "InstanceResponseSnapshotV1": {
@@ -3990,6 +4266,7 @@
           "creating",
           "creating_error",
           "creating_error_gpu",
+          "creating_error_capacity",
           "creating_network_error",
           "creating_error_quota",
           "creating_error_quota_ram",
@@ -4006,6 +4283,7 @@
           "retyping_error_quota_ram",
           "retyping_error_quota_vcpu",
           "retyping_error_quota",
+          "retyping_error_capacity",
           "stopping_pending",
           "stopping",
           "stopping_error",
@@ -4043,6 +4321,28 @@
         "example": {
           "name": "new-instance-name"
         }
+      },
+      "Interface": {
+        "type": "object",
+        "properties": {
+          "security_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ID"
+            },
+            "title": "Security Groups",
+            "default": []
+          },
+          "subnets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ID"
+            },
+            "title": "Subnets",
+            "maxItems": 1
+          }
+        },
+        "title": "Interface"
       },
       "IpAddressExpand": {
         "type": "object",
@@ -4299,6 +4599,89 @@
         "example": {
           "name": "some_resource_name"
         }
+      },
+      "NetworkInterfaceAttachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The unique identifier of the network interface."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "A human-readable name assigned to the network interface."
+          },
+          "vpc": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ID"
+              },
+              {
+                "$ref": "#/components/schemas/Name"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vpc",
+            "description": "The Virtual Private Cloud (VPC) where this interface will be attached.",
+            "default": {
+              "name": "vpc_default"
+            }
+          },
+          "subnets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ID"
+            },
+            "title": "Subnets",
+            "maxItems": 1,
+            "description": "A list containing the subnet ID associated with this interface (maximum of 1 subnet)."
+          },
+          "security_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ID"
+            },
+            "title": "Security Groups",
+            "description": "A list of security group IDs applied to this network interface for traffic filtering.",
+            "default": []
+          },
+          "associate_public_ip": {
+            "type": "boolean",
+            "title": "Associate Public Ip",
+            "description": "Indicates whether a public IP address should be automatically assigned to this interface.",
+            "default": false
+          },
+          "tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tag",
+            "description": "An optional device role tag exposed to the guest OS via metadata. It ensures reliable interface identification, as network device order is not guaranteed."
+          }
+        },
+        "title": "NetworkInterfaceAttachment"
       },
       "NetworkPortsNew": {
         "type": "object",
@@ -4690,7 +5073,9 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Deprecated: this field is ignored.",
+            "deprecated": true
           }
         },
         "title": "PatchCustomImageRequest",
@@ -4772,6 +5157,17 @@
                 "type": "null"
               }
             ]
+          },
+          "mac_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mac Address"
           }
         },
         "title": "PortNewExpand",
@@ -4791,8 +5187,30 @@
             "type": "string",
             "title": "Name"
           },
+          "vpc_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vpc Id"
+          },
           "ipAddresses": {
             "$ref": "#/components/schemas/IpAddressExpand"
+          },
+          "mac_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mac Address"
           }
         },
         "title": "PortV1Expand",
@@ -4810,20 +5228,6 @@
           "br-mgl1",
           "br-ne1"
         ]
-      },
-      "SecurityGroups": {
-        "type": "object",
-        "properties": {
-          "security_groups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ID"
-            },
-            "title": "Security Groups",
-            "default": []
-          }
-        },
-        "title": "SecurityGroups"
       },
       "SnapshotCopyRequest": {
         "type": "object",
@@ -5077,6 +5481,11 @@
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
                 }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                }
               ]
             },
             "vpc": {
@@ -5137,6 +5546,24 @@
           "id",
           "name"
         ]
+      }
+    },
+    "securitySchemes": {
+      "OAuth2": {
+        "type": "oauth2",
+        "description": "OAuth2 via IDPA",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://id.magalu.com",
+            "tokenUrl": "https://id.magalu.com/oauth/token",
+            "scopes": {
+              "virtual-machine.write": "Escrever informacoes de recursos VM IaaS",
+              "virtual-machine.read": "Ler informacoes de recursos VM IaaS",
+              "virtual-machine-internal.write": "Escrever informacoes de recursos internos VM IaaS",
+              "virtual-machine-internal.read": "Ler informacoes de recursos internos VM IaaS"
+            }
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
## What does this PR do?
Adiciona suporte para multiplas VNICs por meio da flag --network.profile

```
mgc vm instances create \
  --ssh-key-name <SSH_KEY_NAME>\
  --image.id=<UUID> \
  --machine-type.id=<UUID> \
  --name=<NAME> \
  --network-profile.interfaces='[{"associate_public_ip":true,"subnets":[{"id":"<UUID"}],"tag":"primary","vpc":{"id":"<UUID"}},{"associate_public_ip":false,"subnets":[{"id":"<UUID>"}],"tag":"secondary","vpc":{"id":"<UUID"}}]'
```


## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works