### PR TITLE
fix: bs specs downgrade

### DIFF
--- a/specs/block-storage.jaxyendy.openapi.json
+++ b/specs/block-storage.jaxyendy.openapi.json
@@ -1647,7 +1647,10 @@
           }
         },
         "x-viveiro": true,
-        "x-permission-name": "bs_volume_create"
+        "x-permission-name": "bs_volume_create",
+        "x-mgc-confirmable": {
+          "message": "{{if not .parameters.encrypted}}WARNING: You are creating a volume WITHOUT encryption. \nThe recommended policy is to keep encryption enabled. \nAre you sure you want to proceed without encryption?{{end}}"
+        }
       }
     },
     "/v1/volumes/{id}": {


### PR DESCRIPTION
## What does this PR do?
Corrige bug que, ao executar o comando, `make downgrade specs` removia a tag `x-mgc-confirmable`  da spec `block-storage.jaxyendy.openapi.yaml`

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works