### PR TITLE
feat: Add support for labels when creating nodepools

### DIFF
--- a/mgc/cli/docs/kubernetes/nodepool/create.md
+++ b/mgc/cli/docs/kubernetes/nodepool/create.md
@@ -12,7 +12,7 @@ mgc kubernetes nodepool create [cluster-id] [flags]
 
 ## Examples:
 ```
-mgc kubernetes nodepool create --auto-scale.max-replicas=5 --auto-scale.min-replicas=2 --flavor="BV2-4-40" --max-pods-per-node=32 --name="nodepool-example" --network.subnet-ids='["627c1f78-f9a6-4419-b582-a982144ff6bc","57b69486-e800-4cc3-92e2-6037b4cafe35"]' --replicas=3
+mgc kubernetes nodepool create --auto-scale.max-replicas=5 --auto-scale.min-replicas=2 --flavor="BV2-4-40" --labels='{"label-key":"value"}' --max-pods-per-node=32 --name="nodepool-example" --network.subnet-ids='["627c1f78-f9a6-4419-b582-a982144ff6bc","57b69486-e800-4cc3-92e2-6037b4cafe35"]' --replicas=3
 ```
 
 ## Flags:
@@ -36,6 +36,8 @@ mgc kubernetes nodepool create --auto-scale.max-replicas=5 --auto-scale.min-repl
                                         
                                         For V1 Clusters, the list of available flavors can be retrieved using the /v1/flavors endpoint (deprecated) or via the MGC CLI with the command 'kubernetes flavors list'. (required)
 -h, --help                              help for create
+    --labels object                     Key/value pairs attached to the node pool nodes.
+                                        Use --labels=help for more details
     --max-pods-per-node integer         Maximum number of Pods allowed per node.
                                          (range: 8 - 110)
     --name string                       Name of the node pool. The name is primarily for idempotence and must be unique within a namespace. The name cannot be changed.

--- a/mgc/sdk/openapi/openapis/kubernetes.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/kubernetes.openapi.yaml
@@ -1010,19 +1010,20 @@ paths:
                     \ \\\n  --header 'content-type: application/json' \\\n  --header\
                     \ 'x-tenant-id: SOME_STRING_VALUE' \\\n  --data '{\"name\":\"\
                     nodepool-example\",\"flavor\":\"BV2-4-40\",\"replicas\":3,\"tags\"\
-                    :[\"tag-value1\"],\"taints\":[{\"key\":\"example-key\",\"value\"\
-                    :\"value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\"\
-                    :2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\"\
-                    :[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"\
+                    :[\"tag-value1\"],\"labels\":{\"label-key\":\"value\"},\"taints\"\
+                    :[{\"key\":\"example-key\",\"value\":\"value1\",\"effect\":\"\
+                    NoSchedule\"}],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\"\
+                    :5},\"max_pods_per_node\":32,\"availability_zones\":[\"a\",\"\
+                    b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"\
                     ]]}}'"
             -   lang: Shell + Httpie
                 source: "echo '{\"name\":\"nodepool-example\",\"flavor\":\"BV2-4-40\"\
-                    ,\"replicas\":3,\"tags\":[\"tag-value1\"],\"taints\":[{\"key\"\
-                    :\"example-key\",\"value\":\"value1\",\"effect\":\"NoSchedule\"\
-                    }],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\":5},\"max_pods_per_node\"\
-                    :32,\"availability_zones\":[\"a\",\"b\",\"c\"],\"network\":{\"\
-                    subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"]]}}' |\
-                    \  \\\n  http POST https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools\
+                    ,\"replicas\":3,\"tags\":[\"tag-value1\"],\"labels\":{\"label-key\"\
+                    :\"value\"},\"taints\":[{\"key\":\"example-key\",\"value\":\"\
+                    value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\"\
+                    :2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\"\
+                    :[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"\
+                    ]]}}' |  \\\n  http POST https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools\
                     \ \\\n  Authorization:'Bearer REPLACE_BEARER_TOKEN' \\\n  content-type:application/json\
                     \ \\\n  x-tenant-id:SOME_STRING_VALUE"
             -   lang: Go + Native
@@ -1031,11 +1032,12 @@ paths:
                     https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools\"\
                     \n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"nodepool-example\\\
                     \",\\\"flavor\\\":\\\"BV2-4-40\\\",\\\"replicas\\\":3,\\\"tags\\\
-                    \":[\\\"tag-value1\\\"],\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\
-                    \",\\\"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\
-                    \"}],\\\"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\
-                    \":5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\"\
-                    :[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\
+                    \":[\\\"tag-value1\\\"],\\\"labels\\\":{\\\"label-key\\\":\\\"\
+                    value\\\"},\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\",\\\
+                    \"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\
+                    \"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\"\
+                    :5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\":[\\\
+                    \"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\
                     \":[[\\\"11111111-1111-1111-1111-111111111111\\\"]]}}\")\n\n\t\
                     req, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"\
                     content-type\", \"application/json\")\n\treq.Header.Add(\"x-tenant-id\"\
@@ -1047,12 +1049,13 @@ paths:
                 source: "import http.client\n\nconn = http.client.HTTPSConnection(\"\
                     api-mke.pre-prod.br-ne-1.jaxyendy.com\")\n\npayload = \"{\\\"\
                     name\\\":\\\"nodepool-example\\\",\\\"flavor\\\":\\\"BV2-4-40\\\
-                    \",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"taints\\\
-                    \":[{\\\"key\\\":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\
-                    \",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"\
-                    min_replicas\\\":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\
-                    \":32,\\\"availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"\
-                    ],\\\"network\\\":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\
+                    \",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"labels\\\
+                    \":{\\\"label-key\\\":\\\"value\\\"},\\\"taints\\\":[{\\\"key\\\
+                    \":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\",\\\"effect\\\
+                    \":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"min_replicas\\\
+                    \":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\":32,\\\"\
+                    availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\
+                    \":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\
                     \"]]}}\"\n\nheaders = {\n    'content-type': \"application/json\"\
                     ,\n    'x-tenant-id': \"SOME_STRING_VALUE\",\n    'Authorization':\
                     \ \"Bearer REPLACE_BEARER_TOKEN\"\n    }\n\nconn.request(\"POST\"\
@@ -1071,11 +1074,11 @@ paths:
                     end\", function () {\n    const body = Buffer.concat(chunks);\n\
                     \    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n\
                     \  name: 'nodepool-example',\n  flavor: 'BV2-4-40',\n  replicas:\
-                    \ 3,\n  tags: ['tag-value1'],\n  taints: [{key: 'example-key',\
-                    \ value: 'value1', effect: 'NoSchedule'}],\n  auto_scale: {min_replicas:\
-                    \ 2, max_replicas: 5},\n  max_pods_per_node: 32,\n  availability_zones:\
-                    \ ['a', 'b', 'c'],\n  network: {subnet_ids: [['11111111-1111-1111-1111-111111111111']]}\n\
-                    }));\nreq.end();"
+                    \ 3,\n  tags: ['tag-value1'],\n  labels: {'label-key': 'value'},\n\
+                    \  taints: [{key: 'example-key', value: 'value1', effect: 'NoSchedule'}],\n\
+                    \  auto_scale: {min_replicas: 2, max_replicas: 5},\n  max_pods_per_node:\
+                    \ 32,\n  availability_zones: ['a', 'b', 'c'],\n  network: {subnet_ids:\
+                    \ [['11111111-1111-1111-1111-111111111111']]}\n}));\nreq.end();"
             -   lang: Ruby + Native
                 source: 'require ''uri''
 
@@ -1102,7 +1105,7 @@ paths:
 
                     request["Authorization"] = ''Bearer REPLACE_BEARER_TOKEN''
 
-                    request.body = "{\"name\":\"nodepool-example\",\"flavor\":\"BV2-4-40\",\"replicas\":3,\"tags\":[\"tag-value1\"],\"taints\":[{\"key\":\"example-key\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\":[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"]]}}"
+                    request.body = "{\"name\":\"nodepool-example\",\"flavor\":\"BV2-4-40\",\"replicas\":3,\"tags\":[\"tag-value1\"],\"labels\":{\"label-key\":\"value\"},\"taints\":[{\"key\":\"example-key\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\":[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"]]}}"
 
 
                     response = http.request(request)
@@ -2489,10 +2492,10 @@ components:
             - network
         CreateNodePoolRequest:
             type: object
-            description: Object of the node pool request
             properties:
                 name:
                     type: string
+                    maxLength: 63
                     description: "Name of the node pool. The name is primarily for\
                         \ idempotence and must be unique within a namespace. The name\
                         \ cannot be changed.\nThe name must follow the following rules:\n\
@@ -2501,44 +2504,45 @@ components:
                         \ start with an alphabetic character\n  - Must end with an\
                         \ alphanumeric character\n"
                     example: nodepool-example
-                    maxLength: 63
                 flavor:
                     $ref: '#/components/schemas/NodePoolFlavor'
                 replicas:
                     type: integer
                     description: Number of replicas of the nodes in the node pool.
-                    example: 3
                     default: 1
                     nullable: true
+                    example: 3
                     x-oapi-codegen-extra-tags:
                         binding: required
                 tags:
                     type: array
-                    description: List of tags applied to the node pool.
                     items:
                         type: string
                         description: Items from the list of tags applied to the node
                             pool.
                         example: tag-value1
+                    description: List of tags applied to the node pool.
                     deprecated: true
+                labels:
+                    $ref: '#/components/schemas/NodePoolLabels'
                 taints:
                     type: array
-                    description: Property associating a set of nodes.
                     items:
                         $ref: '#/components/schemas/Taint'
+                    description: Property associating a set of nodes.
                 auto_scale:
                     $ref: '#/components/schemas/AutoScale'
                 max_pods_per_node:
                     $ref: '#/components/schemas/MaxPodsPerNode'
                 availability_zones:
                     $ref: '#/components/schemas/AvailabilityZones'
-                    deprecated: true
                 network:
                     $ref: '#/components/schemas/NodePoolNetworkRequest'
             required:
             - name
             - flavor
             - replicas
+            description: Object of the node pool request
         NodePoolFlavor:
             type: string
             description: 'Name of the machine type. The machine type defines the CPU,
@@ -2554,6 +2558,13 @@ components:
                 the /v1/flavors endpoint (deprecated) or via the MGC CLI with the
                 command `kubernetes flavors list`.'
             example: BV2-4-40
+        NodePoolLabels:
+            type: object
+            additionalProperties:
+                type: string
+            description: Key/value pairs attached to the node pool nodes.
+            example:
+                label-key: value
         PatchNodePoolRequest:
             type: object
             description: Object of the node pool modification request.

--- a/specs/kubernetes.jaxyendy.openapi.json
+++ b/specs/kubernetes.jaxyendy.openapi.json
@@ -965,30 +965,30 @@
           "permission-name": "kubernetes_nodepool_create",
           "product-name": "kubernetes"
         },
-        "x-codeSamples": [
+"x-codeSamples": [
           {
             "lang": "Shell + Curl",
-            "source": "curl --request POST \\\n  --url https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools \\\n  --header 'Authorization: Bearer REPLACE_BEARER_TOKEN' \\\n  --header 'content-type: application/json' \\\n  --header 'x-tenant-id: SOME_STRING_VALUE' \\\n  --data '{\"name\":\"nodepool-example\",\"flavor\":\"BV2-4-40\",\"replicas\":3,\"tags\":[\"tag-value1\"],\"taints\":[{\"key\":\"example-key\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\":[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"]]}}'"
+            "source": "curl --request POST \\\n  --url https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools \\\n  --header 'Authorization: Bearer REPLACE_BEARER_TOKEN' \\\n  --header 'content-type: application/json' \\\n  --header 'x-tenant-id: SOME_STRING_VALUE' \\\n  --data '{\"name\":\"nodepool-example\",\"flavor\":\"BV2-4-40\",\"replicas\":3,\"tags\":[\"tag-value1\"],\"labels\":{\"label-key\":\"value\"},\"taints\":[{\"key\":\"example-key\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\":[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"]]}}'"
           },
           {
             "lang": "Shell + Httpie",
-            "source": "echo '{\"name\":\"nodepool-example\",\"flavor\":\"BV2-4-40\",\"replicas\":3,\"tags\":[\"tag-value1\"],\"taints\":[{\"key\":\"example-key\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\":[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"]]}}' |  \\\n  http POST https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools \\\n  Authorization:'Bearer REPLACE_BEARER_TOKEN' \\\n  content-type:application/json \\\n  x-tenant-id:SOME_STRING_VALUE"
+            "source": "echo '{\"name\":\"nodepool-example\",\"flavor\":\"BV2-4-40\",\"replicas\":3,\"tags\":[\"tag-value1\"],\"labels\":{\"label-key\":\"value\"},\"taints\":[{\"key\":\"example-key\",\"value\":\"value1\",\"effect\":\"NoSchedule\"}],\"auto_scale\":{\"min_replicas\":2,\"max_replicas\":5},\"max_pods_per_node\":32,\"availability_zones\":[\"a\",\"b\",\"c\"],\"network\":{\"subnet_ids\":[[\"11111111-1111-1111-1111-111111111111\"]]}}' |  \\\n  http POST https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools \\\n  Authorization:'Bearer REPLACE_BEARER_TOKEN' \\\n  content-type:application/json \\\n  x-tenant-id:SOME_STRING_VALUE"
           },
           {
             "lang": "Go + Native",
-            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools\"\n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"nodepool-example\\\",\\\"flavor\\\":\\\"BV2-4-40\\\",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\"]]}}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\")\n\treq.Header.Add(\"x-tenant-id\", \"SOME_STRING_VALUE\")\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
+            "source": "package main\n\nimport (\n\t\"fmt\"\n\t\"strings\"\n\t\"net/http\"\n\t\"io/ioutil\"\n)\n\nfunc main() {\n\n\turl := \"https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools\"\n\n\tpayload := strings.NewReader(\"{\\\"name\\\":\\\"nodepool-example\\\",\\\"flavor\\\":\\\"BV2-4-40\\\",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"labels\\\":{\\\"label-key\\\":\\\"value\\\"},\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\"]]}}\")\n\n\treq, _ := http.NewRequest(\"POST\", url, payload)\n\n\treq.Header.Add(\"content-type\", \"application/json\")\n\treq.Header.Add(\"x-tenant-id\", \"SOME_STRING_VALUE\")\n\treq.Header.Add(\"Authorization\", \"Bearer REPLACE_BEARER_TOKEN\")\n\n\tres, _ := http.DefaultClient.Do(req)\n\n\tdefer res.Body.Close()\n\tbody, _ := ioutil.ReadAll(res.Body)\n\n\tfmt.Println(res)\n\tfmt.Println(string(body))\n\n}"
           },
           {
             "lang": "Python + Python3",
-            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api-mke.pre-prod.br-ne-1.jaxyendy.com\")\n\npayload = \"{\\\"name\\\":\\\"nodepool-example\\\",\\\"flavor\\\":\\\"BV2-4-40\\\",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\"]]}}\"\n\nheaders = {\n    'content-type': \"application/json\",\n    'x-tenant-id': \"SOME_STRING_VALUE\",\n    'Authorization': \"Bearer REPLACE_BEARER_TOKEN\"\n    }\n\nconn.request(\"POST\", \"/v0/clusters/%7Bcluster_id%7D/node_pools\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
+            "source": "import http.client\n\nconn = http.client.HTTPSConnection(\"api-mke.pre-prod.br-ne-1.jaxyendy.com\")\n\npayload = \"{\\\"name\\\":\\\"nodepool-example\\\",\\\"flavor\\\":\\\"BV2-4-40\\\",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"labels\\\":{\\\"label-key\\\":\\\"value\\\"},\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\"]]}}\"\n\nheaders = {\n    'content-type': \"application/json\",\n    'x-tenant-id': \"SOME_STRING_VALUE\",\n    'Authorization': \"Bearer REPLACE_BEARER_TOKEN\"\n    }\n\nconn.request(\"POST\", \"/v0/clusters/%7Bcluster_id%7D/node_pools\", payload, headers)\n\nres = conn.getresponse()\ndata = res.read()\n\nprint(data.decode(\"utf-8\"))"
           },
           {
             "lang": "Node + Native",
-            "source": "const http = require(\"https\");\n\nconst options = {\n  \"method\": \"POST\",\n  \"hostname\": \"api-mke.pre-prod.br-ne-1.jaxyendy.com\",\n  \"port\": null,\n  \"path\": \"/v0/clusters/%7Bcluster_id%7D/node_pools\",\n  \"headers\": {\n    \"content-type\": \"application/json\",\n    \"x-tenant-id\": \"SOME_STRING_VALUE\",\n    \"Authorization\": \"Bearer REPLACE_BEARER_TOKEN\"\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on(\"data\", function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on(\"end\", function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  name: 'nodepool-example',\n  flavor: 'BV2-4-40',\n  replicas: 3,\n  tags: ['tag-value1'],\n  taints: [{key: 'example-key', value: 'value1', effect: 'NoSchedule'}],\n  auto_scale: {min_replicas: 2, max_replicas: 5},\n  max_pods_per_node: 32,\n  availability_zones: ['a', 'b', 'c'],\n  network: {subnet_ids: [['11111111-1111-1111-1111-111111111111']]}\n}));\nreq.end();"
+            "source": "const http = require(\"https\");\n\nconst options = {\n  \"method\": \"POST\",\n  \"hostname\": \"api-mke.pre-prod.br-ne-1.jaxyendy.com\",\n  \"port\": null,\n  \"path\": \"/v0/clusters/%7Bcluster_id%7D/node_pools\",\n  \"headers\": {\n    \"content-type\": \"application/json\",\n    \"x-tenant-id\": \"SOME_STRING_VALUE\",\n    \"Authorization\": \"Bearer REPLACE_BEARER_TOKEN\"\n  }\n};\n\nconst req = http.request(options, function (res) {\n  const chunks = [];\n\n  res.on(\"data\", function (chunk) {\n    chunks.push(chunk);\n  });\n\n  res.on(\"end\", function () {\n    const body = Buffer.concat(chunks);\n    console.log(body.toString());\n  });\n});\n\nreq.write(JSON.stringify({\n  name: 'nodepool-example',\n  flavor: 'BV2-4-40',\n  replicas: 3,\n  tags: ['tag-value1'],\n  labels: {'label-key': 'value'},\n  taints: [{key: 'example-key', value: 'value1', effect: 'NoSchedule'}],\n  auto_scale: {min_replicas: 2, max_replicas: 5},\n  max_pods_per_node: 32,\n  availability_zones: ['a', 'b', 'c'],\n  network: {subnet_ids: [['11111111-1111-1111-1111-111111111111']]}\n}));\nreq.end();"
           },
           {
             "lang": "Ruby + Native",
-            "source": "require 'uri'\nrequire 'net/http'\nrequire 'openssl'\n\nurl = URI(\"https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\nhttp.verify_mode = OpenSSL::SSL::VERIFY_NONE\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"content-type\"] = 'application/json'\nrequest[\"x-tenant-id\"] = 'SOME_STRING_VALUE'\nrequest[\"Authorization\"] = 'Bearer REPLACE_BEARER_TOKEN'\nrequest.body = \"{\\\"name\\\":\\\"nodepool-example\\\",\\\"flavor\\\":\\\"BV2-4-40\\\",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\"]]}}\"\n\nresponse = http.request(request)\nputs response.read_body"
+            "source": "require 'uri'\nrequire 'net/http'\nrequire 'openssl'\n\nurl = URI(\"https://api-mke.pre-prod.br-ne-1.jaxyendy.com/v0/clusters/%7Bcluster_id%7D/node_pools\")\n\nhttp = Net::HTTP.new(url.host, url.port)\nhttp.use_ssl = true\nhttp.verify_mode = OpenSSL::SSL::VERIFY_NONE\n\nrequest = Net::HTTP::Post.new(url)\nrequest[\"content-type\"] = 'application/json'\nrequest[\"x-tenant-id\"] = 'SOME_STRING_VALUE'\nrequest[\"Authorization\"] = 'Bearer REPLACE_BEARER_TOKEN'\nrequest.body = \"{\\\"name\\\":\\\"nodepool-example\\\",\\\"flavor\\\":\\\"BV2-4-40\\\",\\\"replicas\\\":3,\\\"tags\\\":[\\\"tag-value1\\\"],\\\"labels\\\":{\\\"label-key\\\":\\\"value\\\"},\\\"taints\\\":[{\\\"key\\\":\\\"example-key\\\",\\\"value\\\":\\\"value1\\\",\\\"effect\\\":\\\"NoSchedule\\\"}],\\\"auto_scale\\\":{\\\"min_replicas\\\":2,\\\"max_replicas\\\":5},\\\"max_pods_per_node\\\":32,\\\"availability_zones\\\":[\\\"a\\\",\\\"b\\\",\\\"c\\\"],\\\"network\\\":{\\\"subnet_ids\\\":[[\\\"11111111-1111-1111-1111-111111111111\\\"]]}}\"\n\nresponse = http.request(request)\nputs response.read_body"
           }
         ],
         "parameters": [
@@ -2437,13 +2437,12 @@
       },
       "CreateNodePoolRequest": {
         "type": "object",
-        "description": "Object of the node pool request",
         "properties": {
           "name": {
             "type": "string",
+            "maxLength": 63,
             "description": "Name of the node pool. The name is primarily for idempotence and must be unique within a namespace. The name cannot be changed.\nThe name must follow the following rules:\n  - Must contain a maximum of 63 characters\n  - Must contain only lowercase alphanumeric characters or '-'\n  - Must start with an alphabetic character\n  - Must end with an alphanumeric character\n",
-            "example": "nodepool-example",
-            "maxLength": 63
+            "example": "nodepool-example"
           },
           "flavor": {
             "$ref": "#/components/schemas/NodePoolFlavor"
@@ -2451,29 +2450,32 @@
           "replicas": {
             "type": "integer",
             "description": "Number of replicas of the nodes in the node pool.",
-            "example": 3,
             "default": 1,
             "nullable": true,
+            "example": 3,
             "x-oapi-codegen-extra-tags": {
               "binding": "required"
             }
           },
           "tags": {
             "type": "array",
-            "description": "List of tags applied to the node pool.",
             "items": {
               "type": "string",
               "description": "Items from the list of tags applied to the node pool.",
               "example": "tag-value1"
             },
+            "description": "List of tags applied to the node pool.",
             "deprecated": true
+          },
+          "labels": {
+            "$ref": "#/components/schemas/NodePoolLabels"
           },
           "taints": {
             "type": "array",
-            "description": "Property associating a set of nodes.",
             "items": {
               "$ref": "#/components/schemas/Taint"
-            }
+            },
+            "description": "Property associating a set of nodes."
           },
           "auto_scale": {
             "$ref": "#/components/schemas/AutoScale"
@@ -2482,8 +2484,7 @@
             "$ref": "#/components/schemas/MaxPodsPerNode"
           },
           "availability_zones": {
-            "$ref": "#/components/schemas/AvailabilityZones",
-            "deprecated": true
+            "$ref": "#/components/schemas/AvailabilityZones"
           },
           "network": {
             "$ref": "#/components/schemas/NodePoolNetworkRequest"
@@ -2493,12 +2494,23 @@
           "name",
           "flavor",
           "replicas"
-        ]
+        ],
+        "description": "Object of the node pool request"
       },
       "NodePoolFlavor": {
         "type": "string",
         "description": "Name of the machine type. The machine type defines the CPU, RAM, and storage capacity of the nodes.\nThe full list of available machine types can be found in the Virtual Machine by listing the machine types.\nThe smallest supported machine type is BV2-4-40.\n\nFor V1 Clusters, the list of available flavors can be retrieved using the /v1/flavors endpoint (deprecated) or via the MGC CLI with the command `kubernetes flavors list`.",
         "example": "BV2-4-40"
+      },
+      "NodePoolLabels": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "description": "Key/value pairs attached to the node pool nodes.",
+        "example": {
+          "label-key": "value"
+        }
       },
       "PatchNodePoolRequest": {
         "type": "object",


### PR DESCRIPTION
## What does this PR do?
Adiciona a flag opcional `--labels` no comando `mgc k8s nodepool create`

Exemplo de comando:
`mgc kubernetes nodepool create <CLUSTER_ID>   --name="nodepool-labels-test"   --flavor="BV2-4-40"   --replicas=2   --labels='{"environment":"staging","team":"devX","tier":"backend"}'`

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works