### PR TITLE
feat: select subnet on vm instance create

### DIFF
--- a/mgc/cli/docs/virtual-machine/instances/create.md
+++ b/mgc/cli/docs/virtual-machine/instances/create.md
@@ -12,7 +12,7 @@ mgc virtual-machine instances create [flags]
 
 ## Examples:
 ```
-mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --image.name="some_resource_name" --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name" --volumes='[{"id":"a46594d1-9dc3-4c36-8eb3-071259513854"}]'
+mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --image.name="some_resource_name" --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.interface.subnets='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name" --volumes='[{"id":"a46594d1-9dc3-4c36-8eb3-071259513854"}]'
 ```
 
 ## Flags:
@@ -38,7 +38,7 @@ mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d9
                                                 Use --network=help for more details
     --network.associate-public-ip boolean       network's associate_public_ip property: Associate Public Ip
                                                 This is the same as '--network=associate_public_ip:boolean'.
-    --network.interface object                  network's interface property: Interface (at least one of: single property: id or single property: security_groups)
+    --network.interface object                  network's interface property: Interface (at least one of: single property: id or properties: security_groups and subnets)
                                                 Use --network.interface=help for more details
                                                 This is the same as '--network=interface:object'.
     --network.interface.id string               Interface: Id (between 1 and 255 characters)
@@ -46,6 +46,9 @@ mgc virtual-machine instances create --image.id="9ec75090-2872-4f51-8111-53d05d9
     --network.interface.security-groups array   Interface: Security Groups
                                                 Use --network.interface.security-groups=help for more details
                                                 This is the same as '--network.interface=security_groups:array'.
+    --network.interface.subnets array           Interface: Subnets (at most 1 item)
+                                                Use --network.interface.subnets=help for more details
+                                                This is the same as '--network.interface=subnets:array'.
     --network.vpc object                        network's vpc property: Vpc (at least one of: single property: id or single property: name)
                                                 Use --network.vpc=help for more details
                                                 This is the same as '--network=vpc:object'.

--- a/mgc/cli/docs/virtual-machine/snapshots/restore.md
+++ b/mgc/cli/docs/virtual-machine/snapshots/restore.md
@@ -12,7 +12,7 @@ mgc virtual-machine snapshots restore [id] [flags]
 
 ## Examples:
 ```
-mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name"
+mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --machine-type.name="some_resource_name" --network.associate-public-ip=true --network.interface.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.interface.security-groups='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.interface.subnets='[{"id":"9ec75090-2872-4f51-8111-53d05d96d2c6"}]' --network.vpc.id="9ec75090-2872-4f51-8111-53d05d96d2c6" --network.vpc.name="some_resource_name"
 ```
 
 ## Flags:
@@ -32,7 +32,7 @@ mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111
                                                 Use --network=help for more details
     --network.associate-public-ip boolean       network's associate_public_ip property: Associate Public Ip
                                                 This is the same as '--network=associate_public_ip:boolean'.
-    --network.interface object                  network's interface property: Interface (at least one of: single property: id or single property: security_groups)
+    --network.interface object                  network's interface property: Interface (at least one of: single property: id or properties: security_groups and subnets)
                                                 Use --network.interface=help for more details
                                                 This is the same as '--network=interface:object'.
     --network.interface.id string               Interface: Id (between 1 and 255 characters)
@@ -40,6 +40,9 @@ mgc virtual-machine snapshots restore --machine-type.id="9ec75090-2872-4f51-8111
     --network.interface.security-groups array   Interface: Security Groups
                                                 Use --network.interface.security-groups=help for more details
                                                 This is the same as '--network.interface=security_groups:array'.
+    --network.interface.subnets array           Interface: Subnets (at most 1 item)
+                                                Use --network.interface.subnets=help for more details
+                                                This is the same as '--network.interface=subnets:array'.
     --network.vpc object                        network's vpc property: Vpc (at least one of: single property: id or single property: name)
                                                 Use --network.vpc=help for more details
                                                 This is the same as '--network=vpc:object'.

--- a/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
+++ b/mgc/sdk/openapi/openapis/virtual-machine.openapi.yaml
@@ -3074,6 +3074,8 @@ components:
                         security_groups:
                         -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                         -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                        subnets:
+                        -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                     vpc:
                         id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
                 ssh_key_name: keypair_name_here
@@ -3094,7 +3096,7 @@ components:
                 interface:
                     anyOf:
                     -   $ref: '#/components/schemas/ID'
-                    -   $ref: '#/components/schemas/SecurityGroups'
+                    -   $ref: '#/components/schemas/Interface'
                     title: Interface
                     nullable: true
                 associate_public_ip:
@@ -3108,6 +3110,8 @@ components:
                     security_groups:
                     -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                     -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                    subnets:
+                    -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                 vpc:
                     id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
         InstanceResponseSnapshotV1:
@@ -3580,6 +3584,44 @@ components:
             - name
             example:
                 name: new-instance-name
+        Interface:
+            type: object
+            properties:
+                security_groups:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                                title: Id
+                                maxLength: 255
+                                minLength: 1
+                        title: ID
+                        required:
+                        - id
+                        example:
+                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                    title: Security Groups
+                    default: []
+                subnets:
+                    type: array
+                    items:
+                        type: object
+                        properties:
+                            id:
+                                type: string
+                                title: Id
+                                maxLength: 255
+                                minLength: 1
+                        title: ID
+                        required:
+                        - id
+                        example:
+                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
+                    title: Subnets
+                    maxItems: 1
+            title: Interface
         IpAddressExpand:
             type: object
             properties:
@@ -4807,27 +4849,6 @@ components:
             - br-se1
             - br-mgl1
             - br-ne1
-        SecurityGroups:
-            type: object
-            properties:
-                security_groups:
-                    type: array
-                    items:
-                        type: object
-                        properties:
-                            id:
-                                type: string
-                                title: Id
-                                maxLength: 255
-                                minLength: 1
-                        title: ID
-                        required:
-                        - id
-                        example:
-                            id: 9ec75090-2872-4f51-8111-53d05d96d2c6
-                    title: Security Groups
-                    default: []
-            title: SecurityGroups
         SnapshotCopyRequest:
             type: object
             properties:
@@ -4985,6 +5006,8 @@ components:
                         security_groups:
                         -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                         -   id: 02a2acf3-d6db-4424-ac97-0254cb9c329e
+                        subnets:
+                        -   id: f273fbde-2ddf-4dcd-8c41-342671ac0d17
                     vpc:
                         id: 2ae0b896-855c-456c-b4a5-c8f4e6d2f4f6
                 ssh_key_name: keypair_name_here

--- a/specs/conv.virtual-machine.jaxyendy.openapi.json
+++ b/specs/conv.virtual-machine.jaxyendy.openapi.json
@@ -3413,6 +3413,11 @@
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
                 }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                }
               ]
             },
             "vpc": {
@@ -3452,7 +3457,7 @@
                 "$ref": "#/components/schemas/ID"
               },
               {
-                "$ref": "#/components/schemas/SecurityGroups"
+                "$ref": "#/components/schemas/Interface"
               }
             ],
             "title": "Interface",
@@ -3474,6 +3479,11 @@
               },
               {
                 "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+              }
+            ],
+            "subnets": [
+              {
+                "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
               }
             ]
           },
@@ -4124,6 +4134,58 @@
         "example": {
           "name": "new-instance-name"
         }
+      },
+      "Interface": {
+        "type": "object",
+        "properties": {
+          "security_groups": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "maxLength": 255,
+                  "minLength": 1
+                }
+              },
+              "title": "ID",
+              "required": [
+                "id"
+              ],
+              "example": {
+                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+              }
+            },
+            "title": "Security Groups",
+            "default": []
+          },
+          "subnets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "maxLength": 255,
+                  "minLength": 1
+                }
+              },
+              "title": "ID",
+              "required": [
+                "id"
+              ],
+              "example": {
+                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
+              }
+            },
+            "title": "Subnets",
+            "maxItems": 1
+          }
+        },
+        "title": "Interface"
       },
       "IpAddressExpand": {
         "type": "object",
@@ -5896,35 +5958,6 @@
           "br-ne1"
         ]
       },
-      "SecurityGroups": {
-        "type": "object",
-        "properties": {
-          "security_groups": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string",
-                  "title": "Id",
-                  "maxLength": 255,
-                  "minLength": 1
-                }
-              },
-              "title": "ID",
-              "required": [
-                "id"
-              ],
-              "example": {
-                "id": "9ec75090-2872-4f51-8111-53d05d96d2c6"
-              }
-            },
-            "title": "Security Groups",
-            "default": []
-          }
-        },
-        "title": "SecurityGroups"
-      },
       "SnapshotCopyRequest": {
         "type": "object",
         "properties": {
@@ -6158,6 +6191,11 @@
                 },
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+                }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
                 }
               ]
             },

--- a/specs/virtual-machine.jaxyendy.openapi.json
+++ b/specs/virtual-machine.jaxyendy.openapi.json
@@ -3348,6 +3348,11 @@
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
                 }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
+                }
               ]
             },
             "vpc": {
@@ -3389,7 +3394,7 @@
                 "$ref": "#/components/schemas/ID"
               },
               {
-                "$ref": "#/components/schemas/SecurityGroups"
+                "$ref": "#/components/schemas/Interface"
               },
               {
                 "type": "null"
@@ -3413,6 +3418,11 @@
               },
               {
                 "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+              }
+            ],
+            "subnets": [
+              {
+                "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
               }
             ]
           },
@@ -4043,6 +4053,28 @@
         "example": {
           "name": "new-instance-name"
         }
+      },
+      "Interface": {
+        "type": "object",
+        "properties": {
+          "security_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ID"
+            },
+            "title": "Security Groups",
+            "default": []
+          },
+          "subnets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ID"
+            },
+            "title": "Subnets",
+            "maxItems": 1
+          }
+        },
+        "title": "Interface"
       },
       "IpAddressExpand": {
         "type": "object",
@@ -4811,20 +4843,6 @@
           "br-ne1"
         ]
       },
-      "SecurityGroups": {
-        "type": "object",
-        "properties": {
-          "security_groups": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ID"
-            },
-            "title": "Security Groups",
-            "default": []
-          }
-        },
-        "title": "SecurityGroups"
-      },
       "SnapshotCopyRequest": {
         "type": "object",
         "properties": {
@@ -5076,6 +5094,11 @@
                 },
                 {
                   "id": "02a2acf3-d6db-4424-ac97-0254cb9c329e"
+                }
+              ],
+              "subnets": [
+                {
+                  "id": "f273fbde-2ddf-4dcd-8c41-342671ac0d17"
                 }
               ]
             },


### PR DESCRIPTION
## What does this PR do?
Adiciona a possibilidade de escolher a subnet na criação da VM. A subnet deve pertencer a mesma zona e a mesma AZ. 

```
mgc vm instances create   --ssh-key-name <NAME>  --image.id=<ID>   --machine-type.id=<TYPE_ID>   --name=name  --network.interface.subnets='[{"id":<SUBNET>}}]'
```


## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
