### PR TITLE
fix: restrict documented storage classes to empty and standard

### DIFF
--- a/mgc/cli/docs/object-storage/objects/copy-all.md
+++ b/mgc/cli/docs/object-storage/objects/copy-all.md
@@ -12,7 +12,7 @@ mgc object-storage objects copy-all [src] [dst] [flags]
 
 ## Examples:
 ```
-mgc object-storage objects copy-all --dst="bucket2/dir/" --src="bucket1" --storage-class="cold"
+mgc object-storage objects copy-all --dst="bucket2/dir/" --src="bucket1" --storage-class="standard"
 ```
 
 ## Flags:
@@ -22,7 +22,7 @@ mgc object-storage objects copy-all --dst="bucket2/dir/" --src="bucket1" --stora
                              Use --filter=help for more details
 -h, --help                   help for copy-all
     --src uri                Path of objects in a bucket to be copied (required)
-    --storage-class enum     Copy objects to other storage classes (one of "", "cold", "cold_instant", "glacier_ir" or "standard")
+    --storage-class enum     Copy objects with storage-class setting (one of "" or "standard")
 ```
 
 ## Global Flags:

--- a/mgc/cli/docs/object-storage/objects/copy.md
+++ b/mgc/cli/docs/object-storage/objects/copy.md
@@ -12,7 +12,7 @@ mgc object-storage objects copy [src] [dst] [flags]
 
 ## Examples:
 ```
-mgc object-storage objects copy --dst="bucket2/dir/file.txt" --src="bucket1/file.txt" --storage-class="cold"
+mgc object-storage objects copy --dst="bucket2/dir/file.txt" --src="bucket1/file.txt" --storage-class="standard"
 ```
 
 ## Flags:
@@ -21,7 +21,7 @@ mgc object-storage objects copy --dst="bucket2/dir/file.txt" --src="bucket1/file
 -h, --help                 help for copy
     --obj-version string   Version of the object to be copied
     --src uri              Path of the object in a bucket to be copied (required)
-    --storage-class enum   Copy objects to other storage classes (one of "", "cold", "cold_instant", "glacier_ir" or "standard")
+    --storage-class enum   Copy objects with storage-class setting (one of "" or "standard")
 ```
 
 ## Global Flags:

--- a/mgc/cli/docs/object-storage/objects/upload-dir.md
+++ b/mgc/cli/docs/object-storage/objects/upload-dir.md
@@ -12,7 +12,7 @@ mgc object-storage objects upload-dir [src] [dst] [flags]
 
 ## Examples:
 ```
-mgc object-storage objects upload-dir --dst="my-bucket/dir/" --src="path/to/folder" --storage-class="cold"
+mgc object-storage objects upload-dir --dst="my-bucket/dir/" --src="path/to/folder" --storage-class="standard"
 ```
 
 ## Flags:
@@ -23,7 +23,7 @@ mgc object-storage objects upload-dir --dst="my-bucket/dir/" --src="path/to/fold
 -h, --help                   help for upload-dir
     --shallow                Don't upload subdirectories
     --src directory          Source directory path for upload (required)
-    --storage-class enum     Type of Storage in which to store object (one of "", "cold", "cold_instant", "glacier_ir" or "standard")
+    --storage-class enum     Type of Storage in which to store object (one of "" or "standard")
 ```
 
 ## Global Flags:

--- a/mgc/cli/docs/object-storage/objects/upload.md
+++ b/mgc/cli/docs/object-storage/objects/upload.md
@@ -12,7 +12,7 @@ mgc object-storage objects upload [src] [dst] [flags]
 
 ## Examples:
 ```
-mgc object-storage objects upload --dst="my-bucket/dir/file.txt" --src="./file.txt" --storage-class="cold"
+mgc object-storage objects upload --dst="my-bucket/dir/file.txt" --src="./file.txt" --storage-class="standard"
 ```
 
 ## Flags:
@@ -20,7 +20,7 @@ mgc object-storage objects upload --dst="my-bucket/dir/file.txt" --src="./file.t
     --dst uri              Full destination path in the bucket with desired filename (required)
 -h, --help                 help for upload
     --src file             Source file path to be uploaded (required)
-    --storage-class enum   Type of Storage in which to store object (one of "", "cold", "cold_instant", "glacier_ir" or "standard")
+    --storage-class enum   Type of Storage in which to store object (one of "" or "standard")
 ```
 
 ## Global Flags:

--- a/mgc/sdk/static/object_storage/common/copy.go
+++ b/mgc/sdk/static/object_storage/common/copy.go
@@ -28,13 +28,13 @@ type CopyObjectParams struct {
 	Source       mgcSchemaPkg.URI `json:"src" jsonschema:"description=Path of the object in a bucket to be copied,example=bucket1/file.txt" mgc:"positional"`
 	Destination  mgcSchemaPkg.URI `json:"dst" jsonschema:"description=Full destination path in the bucket with desired filename,example=bucket2/dir/file.txt" mgc:"positional"`
 	Version      string           `json:"obj_version,omitempty" jsonschema:"description=Version of the object to be copied"`
-	StorageClass string           `json:"storage_class,omitempty" jsonschema:"description=Copy objects to other storage classes,example=cold,enum=,enum=standard,enum=cold,enum=glacier_ir,enum=cold_instant,default="`
+	StorageClass string           `json:"storage_class,omitempty" jsonschema:"description=Copy objects with storage-class setting,example=standard,enum=,enum=standard,default="`
 }
 
 type CopyAllObjectsParams struct {
 	Source       mgcSchemaPkg.URI `json:"src" jsonschema:"description=Path of objects in a bucket to be copied,example=bucket1" mgc:"positional"`
 	Destination  mgcSchemaPkg.URI `json:"dst" jsonschema:"description=Full destination path in the bucket,example=bucket2/dir/" mgc:"positional"`
-	StorageClass string           `json:"storage_class,omitempty" jsonschema:"description=Copy objects to other storage classes,example=cold,enum=,enum=standard,enum=cold,enum=glacier_ir,enum=cold_instant,default="`
+	StorageClass string           `json:"storage_class,omitempty" jsonschema:"description=Copy objects with storage-class setting,example=standard,enum=,enum=standard,default="`
 	Filters      `json:",squash"` // nolint
 }
 

--- a/mgc/sdk/static/object_storage/objects/upload.go
+++ b/mgc/sdk/static/object_storage/objects/upload.go
@@ -14,7 +14,7 @@ import (
 type uploadParams struct {
 	Source       mgcSchemaPkg.FilePath `json:"src" jsonschema:"description=Source file path to be uploaded,example=./file.txt" mgc:"positional"`
 	Destination  mgcSchemaPkg.URI      `json:"dst" jsonschema:"description=Full destination path in the bucket with desired filename,example=my-bucket/dir/file.txt" mgc:"positional"`
-	StorageClass string                `json:"storage_class,omitempty" jsonschema:"description=Type of Storage in which to store object,example=cold,enum=,enum=standard,enum=cold,enum=glacier_ir,enum=cold_instant,default="`
+	StorageClass string                `json:"storage_class,omitempty" jsonschema:"description=Type of Storage in which to store object,example=standard,enum=,enum=standard,default="`
 }
 
 type uploadTemplateResult struct {

--- a/mgc/sdk/static/object_storage/objects/upload_dir.go
+++ b/mgc/sdk/static/object_storage/objects/upload_dir.go
@@ -19,7 +19,7 @@ type uploadDirParams struct {
 	Source         mgcSchemaPkg.DirPath `json:"src" jsonschema:"description=Source directory path for upload,example=path/to/folder" mgc:"positional"`
 	Destination    mgcSchemaPkg.URI     `json:"dst" jsonschema:"description=Full destination path in the bucket,example=my-bucket/dir/" mgc:"positional"`
 	Shallow        bool                 `json:"shallow,omitempty" jsonschema:"description=Don't upload subdirectories,default=false"`
-	StorageClass   string               `json:"storage_class,omitempty" jsonschema:"description=Type of Storage in which to store object,example=cold,enum=,enum=standard,enum=cold,enum=glacier_ir,enum=cold_instant,default="`
+	StorageClass   string               `json:"storage_class,omitempty" jsonschema:"description=Type of Storage in which to store object,example=standard,enum=,enum=standard,default="`
 	common.Filters `json:",squash"`     // nolint
 }
 


### PR DESCRIPTION
## What does this PR do?
This PR updates the CLI documentation, parameter descriptions, and help messages to restrict the accepted `storage-class` options exclusively to empty/default and `'standard'`:

- **CLI Documentation & Help Texts**: Removes references to cold storage class variants (`COLD`, `COLD_INSTANT`, `EVENTUAL_ACCESS`, etc.) from CLI help strings and documentation.
- **Validation Alignment**: Ensures CLI parameter descriptions accurately reflect that only empty (`""`) and `'standard'` storage classes are supported in this context.

## How Has This Been Tested?
  - Updated CLI command and parameter validation tests to verify that help strings and docstrings correctly list only `""` and `'standard'`.

- **Manual Testing**:
  - Executed CLI commands with `--help` flag to verify that updated parameter descriptions display correctly in the terminal.
  - Tested running CLI commands with empty values (`""`), `'standard'`, and deprecated cold values to verify expected parameter handling and error outputs.

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
<img width="1314" height="834" alt="image" src="https://github.com/user-attachments/assets/818a4fa3-bf37-4c6d-b28f-a4ec67207f99" />
