### PR TITLE
Fix: upload dir filename encoding

### DIFF
--- a/mgc/sdk/static/object_storage/common/filename_encoding.go
+++ b/mgc/sdk/static/object_storage/common/filename_encoding.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
+)
+
+var candidateEncodings = []*charmap.Charmap{
+	charmap.Windows1252,
+	charmap.Windows1250,
+	charmap.Windows1251,
+	charmap.Windows1253,
+	charmap.Windows1254,
+	charmap.Windows1257,
+	charmap.ISO8859_1,
+	charmap.CodePage850,
+}
+
+func FixFilenameEncoding(name string) (fixed string, converted bool, err error) {
+	if utf8.ValidString(name) {
+		return name, false, nil
+	}
+
+	for _, enc := range candidateEncodings {
+		decoded, decErr := enc.NewDecoder().String(name)
+		if decErr == nil && utf8.ValidString(decoded) && !hasUndecodableRune(decoded) {
+			return decoded, true, nil
+		}
+	}
+
+	pos, b := firstInvalidByte(name)
+	return "", false, fmt.Errorf("filename contains invalid UTF-8 bytes (position %d, byte 0x%02X) — rename the file and try again", pos, b)
+}
+
+func hasUndecodableRune(s string) bool {
+	for _, r := range s {
+		if r == utf8.RuneError || unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstInvalidByte(s string) (int, byte) {
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size <= 1 {
+			return i, s[i]
+		}
+		i += size
+	}
+	return -1, 0
+}

--- a/mgc/sdk/static/object_storage/common/filename_encoding.go
+++ b/mgc/sdk/static/object_storage/common/filename_encoding.go
@@ -31,8 +31,7 @@ func FixFilenameEncoding(name string) (fixed string, converted bool, err error) 
 		}
 	}
 
-	pos, b := firstInvalidByte(name)
-	return "", false, fmt.Errorf("filename contains invalid UTF-8 bytes (position %d, byte 0x%02X) — rename the file and try again", pos, b)
+	return "", false, fmt.Errorf("filename contains invalid UTF-8 bytes, rename the file and try again")
 }
 
 func hasUndecodableRune(s string) bool {
@@ -42,15 +41,4 @@ func hasUndecodableRune(s string) bool {
 		}
 	}
 	return false
-}
-
-func firstInvalidByte(s string) (int, byte) {
-	for i := 0; i < len(s); {
-		r, size := utf8.DecodeRuneInString(s[i:])
-		if r == utf8.RuneError && size <= 1 {
-			return i, s[i]
-		}
-		i += size
-	}
-	return -1, 0
 }

--- a/mgc/sdk/static/object_storage/common/filename_encoding_test.go
+++ b/mgc/sdk/static/object_storage/common/filename_encoding_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -83,21 +82,5 @@ func TestFixFilenameEncoding(t *testing.T) {
 				t.Errorf("FixFilenameEncoding(%q) converted = %v, want %v", tt.input, converted, tt.wantConverted)
 			}
 		})
-	}
-}
-
-func TestFixFilenameEncoding_ErrorReportsOffendingByte(t *testing.T) {
-	input := "broken-\x81\x01-name.txt"
-
-	_, _, err := FixFilenameEncoding(input)
-	if err == nil {
-		t.Fatalf("expected an error for %q, got none", input)
-	}
-
-	if !strings.Contains(err.Error(), "position 7") {
-		t.Errorf("error message = %q, want it to mention the offending byte position (7)", err.Error())
-	}
-	if !strings.Contains(err.Error(), "0x81") {
-		t.Errorf("error message = %q, want it to mention the offending byte (0x81)", err.Error())
 	}
 }

--- a/mgc/sdk/static/object_storage/common/filename_encoding_test.go
+++ b/mgc/sdk/static/object_storage/common/filename_encoding_test.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFixFilenameEncoding(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantFixed     string
+		wantConverted bool
+		wantErr       bool
+	}{
+		{
+			name:          "already valid UTF-8 is returned unchanged",
+			input:         "café-relatório.txt",
+			wantFixed:     "café-relatório.txt",
+			wantConverted: false,
+		},
+		{
+			name:          "windows-1252 'ô' byte (0xF4) is converted to UTF-8",
+			input:         "rapport-\xf4.txt",
+			wantFixed:     "rapport-ô.txt",
+			wantConverted: true,
+		},
+		{
+			name:          "windows-1252 'ê' byte (0xEA) is converted to UTF-8",
+			input:         "fen\xeatre.txt",
+			wantFixed:     "fenêtre.txt",
+			wantConverted: true,
+		},
+		{
+			name:          "ascii name with a single invalid high byte in the middle",
+			input:         "report\xe9final.txt",
+			wantFixed:     "reportéfinal.txt",
+			wantConverted: true,
+		},
+		{
+			name:          "byte undefined in windows-1252 falls back to windows-1251 (cyrillic)",
+			input:         "test-\x81-name.txt",
+			wantFixed:     "test-Ѓ-name.txt",
+			wantConverted: true,
+		},
+		{
+			name:          "byte undefined in windows-1252 falls back to windows-1250 (central european)",
+			input:         "test-\x8d-name.txt",
+			wantFixed:     "test-Ť-name.txt",
+			wantConverted: true,
+		},
+		{
+			name:          "byte plausible in both windows-1252 and windows-1251 prefers windows-1252 (priority order)",
+			input:         "cost-\x80-report.txt",
+			wantFixed:     "cost-€-report.txt",
+			wantConverted: true,
+		},
+		{
+			name:    "byte with no plausible mapping in any candidate encoding is rejected",
+			input:   "broken-\x81\x01-name.txt",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixed, converted, err := FixFilenameEncoding(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("FixFilenameEncoding(%q) expected an error, got none (fixed=%q)", tt.input, fixed)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("FixFilenameEncoding(%q) unexpected error: %v", tt.input, err)
+			}
+			if fixed != tt.wantFixed {
+				t.Errorf("FixFilenameEncoding(%q) fixed = %q, want %q", tt.input, fixed, tt.wantFixed)
+			}
+			if converted != tt.wantConverted {
+				t.Errorf("FixFilenameEncoding(%q) converted = %v, want %v", tt.input, converted, tt.wantConverted)
+			}
+		})
+	}
+}
+
+func TestFixFilenameEncoding_ErrorReportsOffendingByte(t *testing.T) {
+	input := "broken-\x81\x01-name.txt"
+
+	_, _, err := FixFilenameEncoding(input)
+	if err == nil {
+		t.Fatalf("expected an error for %q, got none", input)
+	}
+
+	if !strings.Contains(err.Error(), "position 7") {
+		t.Errorf("error message = %q, want it to mention the offending byte position (7)", err.Error())
+	}
+	if !strings.Contains(err.Error(), "0x81") {
+		t.Errorf("error message = %q, want it to mention the offending byte (0x81)", err.Error())
+	}
+}

--- a/mgc/sdk/static/object_storage/objects/sync.go
+++ b/mgc/sdk/static/object_storage/objects/sync.go
@@ -2,6 +2,7 @@ package objects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -247,10 +248,15 @@ func processSyncFiles(ctx context.Context, cfg common.Config, source, destinatio
 		close(results)
 	}()
 
+	var errs []error
 	for err := range results {
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%d of %d file(s) failed to sync:\n%w", len(errs), len(files), errors.Join(errs...))
 	}
 
 	return nil
@@ -285,6 +291,16 @@ func processSyncFile(ctx context.Context, cfg common.Config, source, destination
 	}
 
 	pathWithFolder := strings.TrimPrefix(file, basePath)
+
+	fixedPathWithFolder, converted, err := common.FixFilenameEncoding(pathWithFolder)
+	if err != nil {
+		return &common.ObjectError{Url: mgcSchemaPkg.URI(pathWithFolder), Err: fmt.Errorf("skipping file: %w", err)}
+	}
+	if converted {
+		logger().Warnw("converted filename encoding for sync", "original", pathWithFolder, "converted", fixedPathWithFolder)
+	}
+	pathWithFolder = fixedPathWithFolder
+
 	normalizedDestination := destination.JoinPath(pathWithFolder)
 
 	info, err := os.Stat(file)

--- a/mgc/sdk/static/object_storage/objects/upload.go
+++ b/mgc/sdk/static/object_storage/objects/upload.go
@@ -46,6 +46,15 @@ func upload(ctx context.Context, params uploadParams, cfg common.Config) (*uploa
 	fileName := common.ExtractFileName(srcPath)
 
 	if params.Destination.IsRoot() || strings.HasSuffix(fullDstPath.String(), "/") {
+		fixedFileName, converted, err := common.FixFilenameEncoding(fileName)
+		if err != nil {
+			return nil, &common.ObjectError{Url: mgcSchemaPkg.URI(fileName), Err: fmt.Errorf("skipping file: %w", err)}
+		}
+		if converted {
+			logger().Warnw("converted filename encoding for upload", "original", fileName, "converted", fixedFileName)
+		}
+		fileName = fixedFileName
+
 		fullDstPath = fullDstPath.JoinPath(fileName)
 	}
 

--- a/mgc/sdk/static/object_storage/objects/upload_dir.go
+++ b/mgc/sdk/static/object_storage/objects/upload_dir.go
@@ -2,6 +2,7 @@ package objects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -88,9 +89,17 @@ func processFile(ctx context.Context, cfg common.Config, destination mgcSchemaPk
 
 	relPath := common.GetRelativePath(basePath, file)
 
-	dst := destination.JoinPath(relPath)
+	fixedRelPath, converted, err := common.FixFilenameEncoding(relPath)
+	if err != nil {
+		return &common.ObjectError{Url: mgcSchemaPkg.URI(relPath), Err: fmt.Errorf("skipping file: %w", err)}
+	}
+	if converted {
+		logger().Warnw("converted filename encoding for upload", "original", relPath, "converted", fixedRelPath)
+	}
 
-	_, err := upload(
+	dst := destination.JoinPath(fixedRelPath)
+
+	_, err = upload(
 		ctx,
 		uploadParams{Source: mgcSchemaPkg.FilePath(file), Destination: dst, StorageClass: storageClass},
 		cfg,
@@ -155,10 +164,15 @@ func processCurrentAndSubfolders(ctx context.Context, cfg common.Config, destina
 		close(results)
 	}()
 
+	var errs []error
 	for err := range results {
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%d of %d file(s) failed to upload:\n%w", len(errs), len(files), errors.Join(errs...))
 	}
 
 	return nil


### PR DESCRIPTION
## What does this PR do?
Arquivos com nome em encoding inválido (não-UTF-8) hoje quebram o upload em um object storage.

A nova função `FixFilenameEncoding` (`common/filename_encoding.go`) tenta reconhecer o encoding original do nome até achar um que decodifique corretamente. Se nenhum funcionar, retorna um erro em vez de deixar o upload falhar silenciosamente ou corromper o nome do arquivo.

Foi usada uma lista fixa em vez de um pacote de detecção automática de charset (por exemplo: chardet) porque esse tipo de biblioteca precisa de um volume razoável de texto para acertar, e nome de arquivo é curto demais pra dar um resultado confiável. Isso além de utilizar uma dependência externa.

Em `upload_dir.go`, `processFile` passou a chamar `FixFilenameEncoding` no caminho relativo e loga um aviso quando faz a conversão. `processCurrentAndSubfolders` também mudou: em vez de abortar no primeiro erro, agora junta os erros de todos os arquivos do diretório (`errors.Join`) e segue o upload dos demais.

## How Has This Been Tested?
Foram realizados testes unitários e manuais relacionados a essa feature.

## Checklist
- [x] I have run Pre commit `pre-commit run --all-files`
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots/Videos
|Evidência|
|-------------|
|<img width="1447" height="45" alt="image" src="https://github.com/user-attachments/assets/32f40b95-cf06-494f-96cb-f0664969745a" />|